### PR TITLE
ST-Link support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,8 +13,8 @@
 			"sourceMaps": true,
 			"outFiles": [
 				"${workspaceRoot}/out/**/*.js"
-			]
-			// "preLaunchTask": "npm"
+			],
+			"preLaunchTask": "npm"
 		},
 		{
 			"name": "JLink debug server",
@@ -28,8 +28,8 @@
 			"outFiles": [
 				"${workspaceRoot}/out/**/*.js"
 			],
-			"cwd": "${workspaceRoot}"
-			// "preLaunchTask": "npm"
+			"cwd": "${workspaceRoot}",
+			"preLaunchTask": "npm"
 		},
 		{
 			"name": "OpenOCD debug server",
@@ -43,8 +43,8 @@
 			"outFiles": [
 				"${workspaceRoot}/out/**/*.js"
 			],
-			"cwd": "${workspaceRoot}"
-			// "preLaunchTask": "npm"
+			"cwd": "${workspaceRoot}",
+			"preLaunchTask": "npm"
 		},
 		{
 			"name": "PyOCD debug server",
@@ -58,8 +58,8 @@
 			"outFiles": [
 				"${workspaceRoot}/out/**/*.js"
 			],
-			"cwd": "${workspaceRoot}"
-			// "preLaunchTask": "npm"
+			"cwd": "${workspaceRoot}",
+			"preLaunchTask": "npm"
 		},
 		{
 			"name": "Launch Tests",
@@ -71,8 +71,22 @@
 			"sourceMaps": true,
 			"outFiles": [
 				"${workspaceRoot}/out/**/*.js"
-			]
-			// "preLaunchTask": "npm"
+			],
+			"preLaunchTask": "npm"
+		}
+	],
+	"compounds": [
+		{
+			"name": "Extension + JLink Server",
+			"configurations": ["Launch Extension", "JLink debug server"]
+		},
+		{
+			"name": "Extension + OpenOCD Server",
+			"configurations": ["Launch Extension", "OpenOCD debug server"]
+		},
+		{
+			"name": "Extension + PyOCD Server",
+			"configurations": ["Launch Extension", "PyOCD debug server"]
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,21 @@
 			"preLaunchTask": "npm"
 		},
 		{
+			"name": "STLink debug server",
+			"type": "node",
+			"request": "launch",
+			"runtimeArgs": [ "--nolazy" ],
+			"program": "${workspaceRoot}/src/stlink.ts",
+			"stopOnEntry": false,
+			"args": [ "--server=4711" ],
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceRoot}/out/**/*.js"
+			],
+			"cwd": "${workspaceRoot}",
+			"preLaunchTask": "npm"
+		},
+		{
 			"name": "OpenOCD debug server",
 			"type": "node",
 			"request": "launch",
@@ -76,6 +91,10 @@
 		}
 	],
 	"compounds": [
+		{
+			"name": "Extension + STLink Server",
+			"configurations": ["Launch Extension", "STLink debug server"]
+		},
 		{
 			"name": "Extension + JLink Server",
 			"configurations": ["Launch Extension", "JLink debug server"]

--- a/data/SVDMap.json
+++ b/data/SVDMap.json
@@ -7,5 +7,6 @@
 	{ "expression": "STM32F107[a-z0-9]{2}", "flags": "i", "path": "data/STMicro/STM32F107xx.svd" },
 	{ "expression": "STM32F103[a-z0-9]{2}", "flags": "i", "path": "data/STMicro/STM32F103xx.svd" },
 	{ "expression": "STM32F103[a-z0-9]{2}", "flags": "i", "path": "data/STMicro/STM32F103xx.svd" },
-	{ "expression": "STM32F103[a-z0-9]{2}", "flags": "i", "path": "data/STMicro/STM32F103xx.svd" }
+	{ "expression": "STM32F103[a-z0-9]{2}", "flags": "i", "path": "data/STMicro/STM32F103xx.svd" },
+	{ "expression": "STM32L4[x0-9]6.*", "flags": "i", "path": "data/STMicro/STM32L4x6.svd" }
 ]

--- a/package.json
+++ b/package.json
@@ -1,1814 +1,1912 @@
 {
     "activationEvents": [
         "*"
-    ], 
+    ],
     "categories": [
         "Debuggers"
-    ], 
+    ],
     "contributes": {
         "commands": [
             {
-                "command": "cortexPeripherals.updateNode", 
+                "command": "cortexPeripherals.updateNode",
                 "title": "Update"
-            }, 
+            },
             {
-                "command": "cortexPeripherals.selectedNode", 
+                "command": "cortexPeripherals.selectedNode",
                 "title": "Selected"
-            }, 
+            },
             {
-                "category": "Cortex-Debug", 
-                "command": "marus25.cortex-debug-openocd.examineMemory", 
+                "category": "Cortex-Debug",
+                "command": "marus25.cortex-debug-openocd.examineMemory",
                 "title": "View Memory"
-            }, 
+            },
             {
-                "category": "Cortex-Debug", 
-                "command": "marus25.cortex-debug-jlink.examineMemory", 
+                "category": "Cortex-Debug",
+                "command": "marus25.cortex-debug-jlink.examineMemory",
                 "title": "View Memory"
-            }, 
+            },
             {
-                "category": "Cortex-Debug", 
-                "command": "marus25.cortex-debug-pyocd.examineMemory", 
+                "category": "Cortex-Debug",
+                "command": "marus25.cortex-debug-stlink.examineMemory",
+                "title": "View Memory"
+            },
+            {
+                "category": "Cortex-Debug",
+                "command": "marus25.cortex-debug-pyocd.examineMemory",
                 "title": "View Memory"
             }
-        ], 
+        ],
         "debuggers": [
             {
                 "configurationAttributes": {
                     "attach": {
                         "properties": {
                             "configFiles": {
-                                "description": "OpenOCD configuration file(s) to load", 
+                                "description": "OpenOCD configuration file(s) to load",
                                 "items": {
                                     "type": "string"
-                                }, 
+                                },
                                 "type": "array"
-                            }, 
+                            },
                             "cwd": {
-                                "description": "Path of project", 
+                                "description": "Path of project",
                                 "type": "string"
-                            }, 
+                            },
                             "debugger_args": {
-                                "default": [], 
-                                "description": "Additional arguments to pass to GDB", 
+                                "default": [],
+                                "description": "Additional arguments to pass to GDB",
                                 "type": "array"
-                            }, 
+                            },
                             "executable": {
-                                "description": "Path of executable", 
+                                "description": "Path of executable",
                                 "type": "string"
-                            }, 
+                            },
                             "gdbpath": {
-                                "default": "arm-none-eabi-gdb", 
-                                "description": "Path to the gdb executable or the command if in PATH", 
+                                "default": "arm-none-eabi-gdb",
+                                "description": "Path to the gdb executable or the command if in PATH",
                                 "type": "string"
-                            }, 
+                            },
                             "graphConfig": {
                                 "items": {
                                     "oneOf": [
                                         {
                                             "properties": {
                                                 "annotate": {
-                                                    "default": true, 
-                                                    "description": "Create annotations on the graph for when the target processor starts and stops execution. (green line for starting execution, red line for stopping execution).", 
+                                                    "default": true,
+                                                    "description": "Create annotations on the graph for when the target processor starts and stops execution. (green line for starting execution, red line for stopping execution).",
                                                     "type": "boolean"
-                                                }, 
+                                                },
                                                 "label": {
-                                                    "description": "Label for Graph", 
+                                                    "description": "Label for Graph",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "maximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value for the X-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value for the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "minimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value for the Y-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value for the Y-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "plots": {
-                                                    "description": "Plot configurations. Data sources must be configured for \"graph\" (or \"advanced\" with a decoder that sends graph data) in the \"swoConfig\" section", 
+                                                    "description": "Plot configurations. Data sources must be configured for \"graph\" (or \"advanced\" with a decoder that sends graph data) in the \"swoConfig\" section",
                                                     "items": {
                                                         "properties": {
                                                             "color": {
-                                                                "pattern": "^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$", 
+                                                                "pattern": "^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$",
                                                                 "type": "string"
-                                                            }, 
+                                                            },
                                                             "graphId": {
-                                                                "description": "Graph Data Source Id for the plot.", 
+                                                                "description": "Graph Data Source Id for the plot.",
                                                                 "type": "string"
-                                                            }, 
+                                                            },
                                                             "label": {
-                                                                "description": "A label for this data set", 
+                                                                "description": "A label for this data set",
                                                                 "type": "string"
                                                             }
-                                                        }, 
+                                                        },
                                                         "required": [
                                                             "graphId"
-                                                        ], 
+                                                        ],
                                                         "type": "object"
-                                                    }, 
+                                                    },
                                                     "type": "array"
-                                                }, 
+                                                },
                                                 "timespan": {
-                                                    "default": 30, 
-                                                    "description": "Length of time (seconds) to be plotted on screen.", 
+                                                    "default": 30,
+                                                    "description": "Length of time (seconds) to be plotted on screen.",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "type": {
                                                     "enum": [
                                                         "realtime"
-                                                    ], 
+                                                    ],
                                                     "type": "string"
                                                 }
-                                            }, 
+                                            },
                                             "required": [
-                                                "label", 
-                                                "plots", 
-                                                "minimum", 
+                                                "label",
+                                                "plots",
+                                                "minimum",
                                                 "maximum"
-                                            ], 
+                                            ],
                                             "type": "object"
-                                        }, 
+                                        },
                                         {
                                             "properties": {
                                                 "label": {
-                                                    "description": "Label for graph", 
+                                                    "description": "Label for graph",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "timespan": {
-                                                    "default": 10, 
-                                                    "description": "The amount of time (seconds) that the XY Plot will show the trace for.", 
+                                                    "default": 10,
+                                                    "description": "The amount of time (seconds) that the XY Plot will show the trace for.",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "type": {
                                                     "enum": [
                                                         "x-y-plot"
-                                                    ], 
+                                                    ],
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "xGraphId": {
-                                                    "description": "Graph Data Source Id for the X axis", 
+                                                    "description": "Graph Data Source Id for the X axis",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "xMaximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value on the X-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value on the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "xMinimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value on the X-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value on the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "yGraphId": {
-                                                    "description": "Graph Data Source Id Port for the Y axis", 
+                                                    "description": "Graph Data Source Id Port for the Y axis",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "yMaximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value on the Y-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value on the Y-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "yMinimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value on the Y-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value on the Y-Axis",
                                                     "type": "number"
                                                 }
-                                            }, 
+                                            },
                                             "required": [
-                                                "xGraphId", 
-                                                "yGraphId", 
+                                                "xGraphId",
+                                                "yGraphId",
                                                 "label"
-                                            ], 
+                                            ],
                                             "type": "object"
                                         }
                                     ]
-                                }, 
+                                },
                                 "type": "array"
-                            }, 
+                            },
                             "openOCDPath": {
-                                "default": "openocd", 
-                                "description": "Path to the openocd executable", 
+                                "default": "openocd",
+                                "description": "Path to the openocd executable",
                                 "type": "string"
-                            }, 
+                            },
                             "printCalls": {
-                                "default": false, 
-                                "description": "Prints all GDB calls to the console", 
+                                "default": false,
+                                "description": "Prints all GDB calls to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "showDevDebugOutput": {
-                                "default": false, 
-                                "description": "Prints all GDB responses to the console", 
+                                "default": false,
+                                "description": "Prints all GDB responses to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "svdFile": {
-                                "default": null, 
-                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.", 
+                                "default": null,
+                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.",
                                 "type": "string"
-                            }, 
+                            },
                             "swoConfig": {
                                 "properties": {
                                     "cpuFrequency": {
-                                        "default": 0, 
-                                        "description": "Target CPU frequency in Hz; 0 will attempt to automatically calculate.", 
+                                        "default": 0,
+                                        "description": "Target CPU frequency in Hz; 0 will attempt to automatically calculate.",
                                         "type": "number"
-                                    }, 
+                                    },
                                     "enabled": {
-                                        "default": false, 
-                                        "description": "Enable SWO decoding.", 
+                                        "default": false,
+                                        "description": "Enable SWO decoding.",
                                         "type": "boolean"
-                                    }, 
+                                    },
                                     "ports": {
-                                        "description": "SWO Port Configuration", 
+                                        "description": "SWO Port Configuration",
                                         "items": {
                                             "anyOf": [
                                                 {
                                                     "properties": {
                                                         "label": {
-                                                            "description": "A label for the output window.", 
+                                                            "description": "A label for the output window.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "SWO Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "SWO Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "console"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
                                                         "number"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "encoding": {
-                                                            "default": "unsigned", 
-                                                            "description": "This property is only used for binary and graph output formats.", 
+                                                            "default": "unsigned",
+                                                            "description": "This property is only used for binary and graph output formats.",
                                                             "enum": [
-                                                                "unsigned", 
-                                                                "signed", 
-                                                                "Q16.16", 
+                                                                "unsigned",
+                                                                "signed",
+                                                                "Q16.16",
                                                                 "float"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "label": {
-                                                            "description": "A label for the output window.", 
+                                                            "description": "A label for the output window.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "scale": {
-                                                            "default": 1, 
-                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625", 
+                                                            "default": 1,
+                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625",
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "binary"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
                                                         "number"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "encoding": {
-                                                            "default": "unsigned", 
-                                                            "description": "This property is only used for binary and graph output formats.", 
+                                                            "default": "unsigned",
+                                                            "description": "This property is only used for binary and graph output formats.",
                                                             "enum": [
-                                                                "unsigned", 
-                                                                "signed", 
-                                                                "Q16.16", 
+                                                                "unsigned",
+                                                                "signed",
+                                                                "Q16.16",
                                                                 "float"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "graphId": {
-                                                            "description": "The identifier to use for this data in graph configurations.", 
+                                                            "description": "The identifier to use for this data in graph configurations.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "scale": {
-                                                            "default": 1, 
-                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625", 
+                                                            "default": 1,
+                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625",
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "graph"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
-                                                        "number", 
+                                                        "number",
                                                         "graphId"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "config": {
-                                                            "additionalProperties": true, 
+                                                            "additionalProperties": true,
                                                             "type": "object"
-                                                        }, 
+                                                        },
                                                         "decoder": {
-                                                            "description": "Path to a javascript module to implement the decoding functionality.", 
+                                                            "description": "Path to a javascript module to implement the decoding functionality.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "advanced"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
-                                                        "number", 
+                                                        "number",
                                                         "decoder"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
                                                 }
                                             ]
-                                        }, 
+                                        },
                                         "type": "array"
-                                    }, 
+                                    },
                                     "swoFrequency": {
-                                        "default": 0, 
-                                        "description": "SWO frequency in Hz; 0 will attempt to automatically calculate.", 
+                                        "default": 0,
+                                        "description": "SWO frequency in Hz; 0 will attempt to automatically calculate.",
                                         "type": "number"
                                     }
-                                }, 
-                                "required": [], 
+                                },
+                                "required": [],
                                 "type": "object"
                             }
-                        }, 
+                        },
                         "required": [
-                            "executable", 
+                            "executable",
                             "configFiles"
                         ]
-                    }, 
+                    },
                     "launch": {
                         "properties": {
                             "configFiles": {
-                                "description": "OpenOCD configuration file(s) to load", 
+                                "description": "OpenOCD configuration file(s) to load",
                                 "items": {
                                     "type": "string"
-                                }, 
+                                },
                                 "type": "array"
-                            }, 
+                            },
                             "cwd": {
-                                "description": "Path of project", 
+                                "description": "Path of project",
                                 "type": "string"
-                            }, 
+                            },
                             "debugger_args": {
-                                "default": [], 
-                                "description": "Additional arguments to pass to GDB", 
+                                "default": [],
+                                "description": "Additional arguments to pass to GDB",
                                 "type": "array"
-                            }, 
+                            },
                             "executable": {
-                                "description": "Path of executable", 
+                                "description": "Path of executable",
                                 "type": "string"
-                            }, 
+                            },
                             "gdbpath": {
-                                "default": "arm-none-eabi-gdb", 
-                                "description": "Path to the gdb executable or the command if in PATH", 
+                                "default": "arm-none-eabi-gdb",
+                                "description": "Path to the gdb executable or the command if in PATH",
                                 "type": "string"
-                            }, 
+                            },
                             "graphConfig": {
                                 "items": {
                                     "oneOf": [
                                         {
                                             "properties": {
                                                 "annotate": {
-                                                    "default": true, 
-                                                    "description": "Create annotations on the graph for when the target processor starts and stops execution. (green line for starting execution, red line for stopping execution).", 
+                                                    "default": true,
+                                                    "description": "Create annotations on the graph for when the target processor starts and stops execution. (green line for starting execution, red line for stopping execution).",
                                                     "type": "boolean"
-                                                }, 
+                                                },
                                                 "label": {
-                                                    "description": "Label for Graph", 
+                                                    "description": "Label for Graph",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "maximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value for the X-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value for the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "minimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value for the Y-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value for the Y-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "plots": {
-                                                    "description": "Plot configurations. Data sources must be configured for \"graph\" (or \"advanced\" with a decoder that sends graph data) in the \"swoConfig\" section", 
+                                                    "description": "Plot configurations. Data sources must be configured for \"graph\" (or \"advanced\" with a decoder that sends graph data) in the \"swoConfig\" section",
                                                     "items": {
                                                         "properties": {
                                                             "color": {
-                                                                "pattern": "^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$", 
+                                                                "pattern": "^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$",
                                                                 "type": "string"
-                                                            }, 
+                                                            },
                                                             "graphId": {
-                                                                "description": "Graph Data Source Id for the plot.", 
+                                                                "description": "Graph Data Source Id for the plot.",
                                                                 "type": "string"
-                                                            }, 
+                                                            },
                                                             "label": {
-                                                                "description": "A label for this data set", 
+                                                                "description": "A label for this data set",
                                                                 "type": "string"
                                                             }
-                                                        }, 
+                                                        },
                                                         "required": [
                                                             "graphId"
-                                                        ], 
+                                                        ],
                                                         "type": "object"
-                                                    }, 
+                                                    },
                                                     "type": "array"
-                                                }, 
+                                                },
                                                 "timespan": {
-                                                    "default": 30, 
-                                                    "description": "Length of time (seconds) to be plotted on screen.", 
+                                                    "default": 30,
+                                                    "description": "Length of time (seconds) to be plotted on screen.",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "type": {
                                                     "enum": [
                                                         "realtime"
-                                                    ], 
+                                                    ],
                                                     "type": "string"
                                                 }
-                                            }, 
+                                            },
                                             "required": [
-                                                "label", 
-                                                "plots", 
-                                                "minimum", 
+                                                "label",
+                                                "plots",
+                                                "minimum",
                                                 "maximum"
-                                            ], 
+                                            ],
                                             "type": "object"
-                                        }, 
+                                        },
                                         {
                                             "properties": {
                                                 "label": {
-                                                    "description": "Label for graph", 
+                                                    "description": "Label for graph",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "timespan": {
-                                                    "default": 10, 
-                                                    "description": "The amount of time (seconds) that the XY Plot will show the trace for.", 
+                                                    "default": 10,
+                                                    "description": "The amount of time (seconds) that the XY Plot will show the trace for.",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "type": {
                                                     "enum": [
                                                         "x-y-plot"
-                                                    ], 
+                                                    ],
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "xGraphId": {
-                                                    "description": "Graph Data Source Id for the X axis", 
+                                                    "description": "Graph Data Source Id for the X axis",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "xMaximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value on the X-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value on the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "xMinimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value on the X-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value on the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "yGraphId": {
-                                                    "description": "Graph Data Source Id Port for the Y axis", 
+                                                    "description": "Graph Data Source Id Port for the Y axis",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "yMaximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value on the Y-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value on the Y-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "yMinimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value on the Y-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value on the Y-Axis",
                                                     "type": "number"
                                                 }
-                                            }, 
+                                            },
                                             "required": [
-                                                "xGraphId", 
-                                                "yGraphId", 
+                                                "xGraphId",
+                                                "yGraphId",
                                                 "label"
-                                            ], 
+                                            ],
                                             "type": "object"
                                         }
                                     ]
-                                }, 
+                                },
                                 "type": "array"
-                            }, 
+                            },
                             "openOCDPath": {
-                                "default": "openocd", 
-                                "description": "Path to the openocd executable", 
+                                "default": "openocd",
+                                "description": "Path to the openocd executable",
                                 "type": "string"
-                            }, 
+                            },
                             "printCalls": {
-                                "default": false, 
-                                "description": "Prints all GDB calls to the console", 
+                                "default": false,
+                                "description": "Prints all GDB calls to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "showDevDebugOutput": {
-                                "default": false, 
-                                "description": "Prints all GDB responses to the console", 
+                                "default": false,
+                                "description": "Prints all GDB responses to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "svdFile": {
-                                "default": null, 
-                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.", 
+                                "default": null,
+                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.",
                                 "type": "string"
-                            }, 
+                            },
                             "swoConfig": {
                                 "properties": {
                                     "cpuFrequency": {
-                                        "default": 0, 
-                                        "description": "Target CPU frequency in Hz; 0 will attempt to automatically calculate.", 
+                                        "default": 0,
+                                        "description": "Target CPU frequency in Hz; 0 will attempt to automatically calculate.",
                                         "type": "number"
-                                    }, 
+                                    },
                                     "enabled": {
-                                        "default": false, 
-                                        "description": "Enable SWO decoding.", 
+                                        "default": false,
+                                        "description": "Enable SWO decoding.",
                                         "type": "boolean"
-                                    }, 
+                                    },
                                     "ports": {
-                                        "description": "SWO Port Configuration", 
+                                        "description": "SWO Port Configuration",
                                         "items": {
                                             "anyOf": [
                                                 {
                                                     "properties": {
                                                         "label": {
-                                                            "description": "A label for the output window.", 
+                                                            "description": "A label for the output window.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "SWO Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "SWO Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "console"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
                                                         "number"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "encoding": {
-                                                            "default": "unsigned", 
-                                                            "description": "This property is only used for binary and graph output formats.", 
+                                                            "default": "unsigned",
+                                                            "description": "This property is only used for binary and graph output formats.",
                                                             "enum": [
-                                                                "unsigned", 
-                                                                "signed", 
-                                                                "Q16.16", 
+                                                                "unsigned",
+                                                                "signed",
+                                                                "Q16.16",
                                                                 "float"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "label": {
-                                                            "description": "A label for the output window.", 
+                                                            "description": "A label for the output window.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "scale": {
-                                                            "default": 1, 
-                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625", 
+                                                            "default": 1,
+                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625",
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "binary"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
                                                         "number"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "encoding": {
-                                                            "default": "unsigned", 
-                                                            "description": "This property is only used for binary and graph output formats.", 
+                                                            "default": "unsigned",
+                                                            "description": "This property is only used for binary and graph output formats.",
                                                             "enum": [
-                                                                "unsigned", 
-                                                                "signed", 
-                                                                "Q16.16", 
+                                                                "unsigned",
+                                                                "signed",
+                                                                "Q16.16",
                                                                 "float"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "graphId": {
-                                                            "description": "The identifier to use for this data in graph configurations.", 
+                                                            "description": "The identifier to use for this data in graph configurations.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "scale": {
-                                                            "default": 1, 
-                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625", 
+                                                            "default": 1,
+                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625",
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "graph"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
-                                                        "number", 
+                                                        "number",
                                                         "graphId"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "config": {
-                                                            "additionalProperties": true, 
+                                                            "additionalProperties": true,
                                                             "type": "object"
-                                                        }, 
+                                                        },
                                                         "decoder": {
-                                                            "description": "Path to a javascript module to implement the decoding functionality.", 
+                                                            "description": "Path to a javascript module to implement the decoding functionality.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "advanced"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
-                                                        "number", 
+                                                        "number",
                                                         "decoder"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
                                                 }
                                             ]
-                                        }, 
+                                        },
                                         "type": "array"
-                                    }, 
+                                    },
                                     "swoFrequency": {
-                                        "default": 0, 
-                                        "description": "SWO frequency in Hz; 0 will attempt to automatically calculate.", 
+                                        "default": 0,
+                                        "description": "SWO frequency in Hz; 0 will attempt to automatically calculate.",
                                         "type": "number"
                                     }
-                                }, 
-                                "required": [], 
+                                },
+                                "required": [],
                                 "type": "object"
                             }
-                        }, 
+                        },
                         "required": [
-                            "executable", 
+                            "executable",
                             "configFiles"
                         ]
                     }
-                }, 
+                },
                 "configurationSnippets": [
                     {
                         "body": {
-                            "cwd": "^\"\\${workspaceRoot}\"", 
-                            "executable": "${1:./bin/executable.elf}", 
-                            "name": "${6:Debug Microcontroller}", 
-                            "request": "launch", 
+                            "cwd": "^\"\\${workspaceRoot}\"",
+                            "executable": "${1:./bin/executable.elf}",
+                            "name": "${6:Debug Microcontroller}",
+                            "request": "launch",
                             "type": "openocd-gdb"
-                        }, 
-                        "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + OpenOCD", 
+                        },
+                        "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + OpenOCD",
                         "label": "Cortex Debug: OpenOCD"
                     }
-                ], 
+                ],
                 "enableBreakpointsFor": {
                     "languageIds": [
-                        "c", 
-                        "cpp", 
+                        "c",
+                        "cpp",
                         "asm"
                     ]
-                }, 
-                "extensions": [], 
-                "label": "Cortex Debug: OpenOCD", 
-                "program": "./out/src/openocd.js", 
-                "runtime": "node", 
-                "type": "openocd-gdb", 
+                },
+                "extensions": [],
+                "label": "Cortex Debug: OpenOCD",
+                "program": "./out/src/openocd.js",
+                "runtime": "node",
+                "type": "openocd-gdb",
                 "variables": {}
-            }, 
+            },
             {
                 "configurationAttributes": {
                     "attach": {
                         "properties": {
                             "cwd": {
-                                "description": "Path of project", 
+                                "description": "Path of project",
                                 "type": "string"
-                            }, 
+                            },
                             "debugger_args": {
-                                "default": [], 
-                                "description": "Additional arguments to pass to GDB", 
+                                "default": [],
+                                "description": "Additional arguments to pass to GDB",
                                 "type": "array"
-                            }, 
+                            },
                             "device": {
-                                "default": "", 
-                                "description": "J-Link Target Device Identifier", 
+                                "default": "",
+                                "description": "J-Link Target Device Identifier",
                                 "type": "string"
-                            }, 
+                            },
                             "executable": {
-                                "description": "Path of executable", 
+                                "description": "Path of executable",
                                 "type": "string"
-                            }, 
+                            },
                             "gdbpath": {
-                                "default": "arm-none-eabi-gdb", 
-                                "description": "Path to the gdb executable or the command if in PATH", 
+                                "default": "arm-none-eabi-gdb",
+                                "description": "Path to the gdb executable or the command if in PATH",
                                 "type": "string"
-                            }, 
+                            },
                             "graphConfig": {
                                 "items": {
                                     "oneOf": [
                                         {
                                             "properties": {
                                                 "annotate": {
-                                                    "default": true, 
-                                                    "description": "Create annotations on the graph for when the target processor starts and stops execution. (green line for starting execution, red line for stopping execution).", 
+                                                    "default": true,
+                                                    "description": "Create annotations on the graph for when the target processor starts and stops execution. (green line for starting execution, red line for stopping execution).",
                                                     "type": "boolean"
-                                                }, 
+                                                },
                                                 "label": {
-                                                    "description": "Label for Graph", 
+                                                    "description": "Label for Graph",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "maximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value for the X-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value for the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "minimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value for the Y-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value for the Y-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "plots": {
-                                                    "description": "Plot configurations. Data sources must be configured for \"graph\" (or \"advanced\" with a decoder that sends graph data) in the \"swoConfig\" section", 
+                                                    "description": "Plot configurations. Data sources must be configured for \"graph\" (or \"advanced\" with a decoder that sends graph data) in the \"swoConfig\" section",
                                                     "items": {
                                                         "properties": {
                                                             "color": {
-                                                                "pattern": "^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$", 
+                                                                "pattern": "^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$",
                                                                 "type": "string"
-                                                            }, 
+                                                            },
                                                             "graphId": {
-                                                                "description": "Graph Data Source Id for the plot.", 
+                                                                "description": "Graph Data Source Id for the plot.",
                                                                 "type": "string"
-                                                            }, 
+                                                            },
                                                             "label": {
-                                                                "description": "A label for this data set", 
+                                                                "description": "A label for this data set",
                                                                 "type": "string"
                                                             }
-                                                        }, 
+                                                        },
                                                         "required": [
                                                             "graphId"
-                                                        ], 
+                                                        ],
                                                         "type": "object"
-                                                    }, 
+                                                    },
                                                     "type": "array"
-                                                }, 
+                                                },
                                                 "timespan": {
-                                                    "default": 30, 
-                                                    "description": "Length of time (seconds) to be plotted on screen.", 
+                                                    "default": 30,
+                                                    "description": "Length of time (seconds) to be plotted on screen.",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "type": {
                                                     "enum": [
                                                         "realtime"
-                                                    ], 
+                                                    ],
                                                     "type": "string"
                                                 }
-                                            }, 
+                                            },
                                             "required": [
-                                                "label", 
-                                                "plots", 
-                                                "minimum", 
+                                                "label",
+                                                "plots",
+                                                "minimum",
                                                 "maximum"
-                                            ], 
+                                            ],
                                             "type": "object"
-                                        }, 
+                                        },
                                         {
                                             "properties": {
                                                 "label": {
-                                                    "description": "Label for graph", 
+                                                    "description": "Label for graph",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "timespan": {
-                                                    "default": 10, 
-                                                    "description": "The amount of time (seconds) that the XY Plot will show the trace for.", 
+                                                    "default": 10,
+                                                    "description": "The amount of time (seconds) that the XY Plot will show the trace for.",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "type": {
                                                     "enum": [
                                                         "x-y-plot"
-                                                    ], 
+                                                    ],
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "xGraphId": {
-                                                    "description": "Graph Data Source Id for the X axis", 
+                                                    "description": "Graph Data Source Id for the X axis",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "xMaximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value on the X-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value on the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "xMinimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value on the X-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value on the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "yGraphId": {
-                                                    "description": "Graph Data Source Id Port for the Y axis", 
+                                                    "description": "Graph Data Source Id Port for the Y axis",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "yMaximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value on the Y-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value on the Y-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "yMinimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value on the Y-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value on the Y-Axis",
                                                     "type": "number"
                                                 }
-                                            }, 
+                                            },
                                             "required": [
-                                                "xGraphId", 
-                                                "yGraphId", 
+                                                "xGraphId",
+                                                "yGraphId",
                                                 "label"
-                                            ], 
+                                            ],
                                             "type": "object"
                                         }
                                     ]
-                                }, 
+                                },
                                 "type": "array"
-                            }, 
+                            },
                             "ipAddress": {
-                                "default": null, 
-                                "description": "IP Address for networked J-Link Adapter", 
-                                "pattern": "^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$", 
+                                "default": null,
+                                "description": "IP Address for networked J-Link Adapter",
+                                "pattern": "^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$",
                                 "type": "string"
-                            }, 
+                            },
                             "jlinkpath": {
-                                "default": "JLinkGDBServer", 
-                                "description": "Path to the JLink", 
+                                "default": "JLinkGDBServer",
+                                "description": "Path to the JLink",
                                 "type": "string"
-                            }, 
+                            },
                             "printCalls": {
-                                "default": false, 
-                                "description": "Prints all GDB calls to the console", 
+                                "default": false,
+                                "description": "Prints all GDB calls to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "serialNumber": {
-                                "default": null, 
-                                "description": "J-Link Serial Number - only needed if multiple J-Links are connected to the computer", 
+                                "default": null,
+                                "description": "J-Link Serial Number - only needed if multiple J-Links are connected to the computer",
                                 "type": "string"
-                            }, 
+                            },
                             "showDevDebugOutput": {
-                                "default": false, 
-                                "description": "Prints all GDB responses to the console", 
+                                "default": false,
+                                "description": "Prints all GDB responses to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "svdFile": {
-                                "default": null, 
-                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.", 
+                                "default": null,
+                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.",
                                 "type": "string"
-                            }, 
+                            },
                             "swoConfig": {
                                 "properties": {
                                     "cpuFrequency": {
-                                        "default": 0, 
-                                        "description": "Target CPU frequency in Hz; 0 will attempt to automatically calculate.", 
+                                        "default": 0,
+                                        "description": "Target CPU frequency in Hz; 0 will attempt to automatically calculate.",
                                         "type": "number"
-                                    }, 
+                                    },
                                     "enabled": {
-                                        "default": false, 
-                                        "description": "Enable SWO decoding.", 
+                                        "default": false,
+                                        "description": "Enable SWO decoding.",
                                         "type": "boolean"
-                                    }, 
+                                    },
                                     "ports": {
-                                        "description": "SWO Port Configuration", 
+                                        "description": "SWO Port Configuration",
                                         "items": {
                                             "anyOf": [
                                                 {
                                                     "properties": {
                                                         "label": {
-                                                            "description": "A label for the output window.", 
+                                                            "description": "A label for the output window.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "SWO Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "SWO Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "console"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
                                                         "number"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "encoding": {
-                                                            "default": "unsigned", 
-                                                            "description": "This property is only used for binary and graph output formats.", 
+                                                            "default": "unsigned",
+                                                            "description": "This property is only used for binary and graph output formats.",
                                                             "enum": [
-                                                                "unsigned", 
-                                                                "signed", 
-                                                                "Q16.16", 
+                                                                "unsigned",
+                                                                "signed",
+                                                                "Q16.16",
                                                                 "float"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "label": {
-                                                            "description": "A label for the output window.", 
+                                                            "description": "A label for the output window.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "scale": {
-                                                            "default": 1, 
-                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625", 
+                                                            "default": 1,
+                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625",
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "binary"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
                                                         "number"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "encoding": {
-                                                            "default": "unsigned", 
-                                                            "description": "This property is only used for binary and graph output formats.", 
+                                                            "default": "unsigned",
+                                                            "description": "This property is only used for binary and graph output formats.",
                                                             "enum": [
-                                                                "unsigned", 
-                                                                "signed", 
-                                                                "Q16.16", 
+                                                                "unsigned",
+                                                                "signed",
+                                                                "Q16.16",
                                                                 "float"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "graphId": {
-                                                            "description": "The identifier to use for this data in graph configurations.", 
+                                                            "description": "The identifier to use for this data in graph configurations.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "scale": {
-                                                            "default": 1, 
-                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625", 
+                                                            "default": 1,
+                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625",
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "graph"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
-                                                        "number", 
+                                                        "number",
                                                         "graphId"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "config": {
-                                                            "additionalProperties": true, 
+                                                            "additionalProperties": true,
                                                             "type": "object"
-                                                        }, 
+                                                        },
                                                         "decoder": {
-                                                            "description": "Path to a javascript module to implement the decoding functionality.", 
+                                                            "description": "Path to a javascript module to implement the decoding functionality.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "advanced"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
-                                                        "number", 
+                                                        "number",
                                                         "decoder"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
                                                 }
                                             ]
-                                        }, 
+                                        },
                                         "type": "array"
-                                    }, 
+                                    },
                                     "swoFrequency": {
-                                        "default": 0, 
-                                        "description": "SWO frequency in Hz; 0 will attempt to automatically calculate.", 
+                                        "default": 0,
+                                        "description": "SWO frequency in Hz; 0 will attempt to automatically calculate.",
                                         "type": "number"
                                     }
-                                }, 
-                                "required": [], 
+                                },
+                                "required": [],
                                 "type": "object"
                             }
-                        }, 
+                        },
                         "required": [
-                            "executable", 
+                            "executable",
                             "device"
                         ]
-                    }, 
+                    },
                     "launch": {
                         "properties": {
                             "cwd": {
-                                "description": "Path of project", 
+                                "description": "Path of project",
                                 "type": "string"
-                            }, 
+                            },
                             "debugger_args": {
-                                "default": [], 
-                                "description": "Additional arguments to pass to GDB", 
+                                "default": [],
+                                "description": "Additional arguments to pass to GDB",
                                 "type": "array"
-                            }, 
+                            },
                             "device": {
-                                "default": "", 
-                                "description": "J-Link Target Device Identifier", 
+                                "default": "",
+                                "description": "J-Link Target Device Identifier",
                                 "type": "string"
-                            }, 
+                            },
                             "executable": {
-                                "description": "Path of executable", 
+                                "description": "Path of executable",
                                 "type": "string"
-                            }, 
+                            },
                             "gdbpath": {
-                                "default": "arm-none-eabi-gdb", 
-                                "description": "Path to the gdb executable or the command if in PATH", 
+                                "default": "arm-none-eabi-gdb",
+                                "description": "Path to the gdb executable or the command if in PATH",
                                 "type": "string"
-                            }, 
+                            },
                             "graphConfig": {
                                 "items": {
                                     "oneOf": [
                                         {
                                             "properties": {
                                                 "annotate": {
-                                                    "default": true, 
-                                                    "description": "Create annotations on the graph for when the target processor starts and stops execution. (green line for starting execution, red line for stopping execution).", 
+                                                    "default": true,
+                                                    "description": "Create annotations on the graph for when the target processor starts and stops execution. (green line for starting execution, red line for stopping execution).",
                                                     "type": "boolean"
-                                                }, 
+                                                },
                                                 "label": {
-                                                    "description": "Label for Graph", 
+                                                    "description": "Label for Graph",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "maximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value for the X-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value for the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "minimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value for the Y-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value for the Y-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "plots": {
-                                                    "description": "Plot configurations. Data sources must be configured for \"graph\" (or \"advanced\" with a decoder that sends graph data) in the \"swoConfig\" section", 
+                                                    "description": "Plot configurations. Data sources must be configured for \"graph\" (or \"advanced\" with a decoder that sends graph data) in the \"swoConfig\" section",
                                                     "items": {
                                                         "properties": {
                                                             "color": {
-                                                                "pattern": "^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$", 
+                                                                "pattern": "^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$",
                                                                 "type": "string"
-                                                            }, 
+                                                            },
                                                             "graphId": {
-                                                                "description": "Graph Data Source Id for the plot.", 
+                                                                "description": "Graph Data Source Id for the plot.",
                                                                 "type": "string"
-                                                            }, 
+                                                            },
                                                             "label": {
-                                                                "description": "A label for this data set", 
+                                                                "description": "A label for this data set",
                                                                 "type": "string"
                                                             }
-                                                        }, 
+                                                        },
                                                         "required": [
                                                             "graphId"
-                                                        ], 
+                                                        ],
                                                         "type": "object"
-                                                    }, 
+                                                    },
                                                     "type": "array"
-                                                }, 
+                                                },
                                                 "timespan": {
-                                                    "default": 30, 
-                                                    "description": "Length of time (seconds) to be plotted on screen.", 
+                                                    "default": 30,
+                                                    "description": "Length of time (seconds) to be plotted on screen.",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "type": {
                                                     "enum": [
                                                         "realtime"
-                                                    ], 
+                                                    ],
                                                     "type": "string"
                                                 }
-                                            }, 
+                                            },
                                             "required": [
-                                                "label", 
-                                                "plots", 
-                                                "minimum", 
+                                                "label",
+                                                "plots",
+                                                "minimum",
                                                 "maximum"
-                                            ], 
+                                            ],
                                             "type": "object"
-                                        }, 
+                                        },
                                         {
                                             "properties": {
                                                 "label": {
-                                                    "description": "Label for graph", 
+                                                    "description": "Label for graph",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "timespan": {
-                                                    "default": 10, 
-                                                    "description": "The amount of time (seconds) that the XY Plot will show the trace for.", 
+                                                    "default": 10,
+                                                    "description": "The amount of time (seconds) that the XY Plot will show the trace for.",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "type": {
                                                     "enum": [
                                                         "x-y-plot"
-                                                    ], 
+                                                    ],
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "xGraphId": {
-                                                    "description": "Graph Data Source Id for the X axis", 
+                                                    "description": "Graph Data Source Id for the X axis",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "xMaximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value on the X-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value on the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "xMinimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value on the X-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value on the X-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "yGraphId": {
-                                                    "description": "Graph Data Source Id Port for the Y axis", 
+                                                    "description": "Graph Data Source Id Port for the Y axis",
                                                     "type": "string"
-                                                }, 
+                                                },
                                                 "yMaximum": {
-                                                    "default": 65535, 
-                                                    "description": "Maximum value on the Y-Axis", 
+                                                    "default": 65535,
+                                                    "description": "Maximum value on the Y-Axis",
                                                     "type": "number"
-                                                }, 
+                                                },
                                                 "yMinimum": {
-                                                    "default": 0, 
-                                                    "description": "Minimum value on the Y-Axis", 
+                                                    "default": 0,
+                                                    "description": "Minimum value on the Y-Axis",
                                                     "type": "number"
                                                 }
-                                            }, 
+                                            },
                                             "required": [
-                                                "xGraphId", 
-                                                "yGraphId", 
+                                                "xGraphId",
+                                                "yGraphId",
                                                 "label"
-                                            ], 
+                                            ],
                                             "type": "object"
                                         }
                                     ]
-                                }, 
+                                },
                                 "type": "array"
-                            }, 
+                            },
                             "ipAddress": {
-                                "default": null, 
-                                "description": "IP Address for networked J-Link Adapter", 
-                                "pattern": "^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$", 
+                                "default": null,
+                                "description": "IP Address for networked J-Link Adapter",
+                                "pattern": "^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$",
                                 "type": "string"
-                            }, 
+                            },
                             "jlinkpath": {
-                                "default": "JLinkGDBServer", 
-                                "description": "Path to the JLink", 
+                                "default": "JLinkGDBServer",
+                                "description": "Path to the JLink",
                                 "type": "string"
-                            }, 
+                            },
                             "printCalls": {
-                                "default": false, 
-                                "description": "Prints all GDB calls to the console", 
+                                "default": false,
+                                "description": "Prints all GDB calls to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "serialNumber": {
-                                "default": null, 
-                                "description": "J-Link Serial Number - only needed if multiple J-Links are connected to the computer", 
+                                "default": null,
+                                "description": "J-Link Serial Number - only needed if multiple J-Links are connected to the computer",
                                 "type": "string"
-                            }, 
+                            },
                             "showDevDebugOutput": {
-                                "default": false, 
-                                "description": "Prints all GDB responses to the console", 
+                                "default": false,
+                                "description": "Prints all GDB responses to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "svdFile": {
-                                "default": null, 
-                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.", 
+                                "default": null,
+                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.",
                                 "type": "string"
-                            }, 
+                            },
                             "swoConfig": {
                                 "properties": {
                                     "cpuFrequency": {
-                                        "default": 0, 
-                                        "description": "Target CPU frequency in Hz; 0 will attempt to automatically calculate.", 
+                                        "default": 0,
+                                        "description": "Target CPU frequency in Hz; 0 will attempt to automatically calculate.",
                                         "type": "number"
-                                    }, 
+                                    },
                                     "enabled": {
-                                        "default": false, 
-                                        "description": "Enable SWO decoding.", 
+                                        "default": false,
+                                        "description": "Enable SWO decoding.",
                                         "type": "boolean"
-                                    }, 
+                                    },
                                     "ports": {
-                                        "description": "SWO Port Configuration", 
+                                        "description": "SWO Port Configuration",
                                         "items": {
                                             "anyOf": [
                                                 {
                                                     "properties": {
                                                         "label": {
-                                                            "description": "A label for the output window.", 
+                                                            "description": "A label for the output window.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "SWO Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "SWO Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "console"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
                                                         "number"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "encoding": {
-                                                            "default": "unsigned", 
-                                                            "description": "This property is only used for binary and graph output formats.", 
+                                                            "default": "unsigned",
+                                                            "description": "This property is only used for binary and graph output formats.",
                                                             "enum": [
-                                                                "unsigned", 
-                                                                "signed", 
-                                                                "Q16.16", 
+                                                                "unsigned",
+                                                                "signed",
+                                                                "Q16.16",
                                                                 "float"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "label": {
-                                                            "description": "A label for the output window.", 
+                                                            "description": "A label for the output window.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "scale": {
-                                                            "default": 1, 
-                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625", 
+                                                            "default": 1,
+                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625",
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "binary"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
                                                         "number"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "encoding": {
-                                                            "default": "unsigned", 
-                                                            "description": "This property is only used for binary and graph output formats.", 
+                                                            "default": "unsigned",
+                                                            "description": "This property is only used for binary and graph output formats.",
                                                             "enum": [
-                                                                "unsigned", 
-                                                                "signed", 
-                                                                "Q16.16", 
+                                                                "unsigned",
+                                                                "signed",
+                                                                "Q16.16",
                                                                 "float"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "graphId": {
-                                                            "description": "The identifier to use for this data in graph configurations.", 
+                                                            "description": "The identifier to use for this data in graph configurations.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "scale": {
-                                                            "default": 1, 
-                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625", 
+                                                            "default": 1,
+                                                            "description": "This setting will scale the raw value from the ITM port by the specified value. Can be used, for example, to scale a raw n-bit ADC reading to a voltage value. (e.g to scale a 12-bit ADC reading to a 3.3v scale you would need a scale value of 3.3/4096 = 0.0008056640625",
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "graph"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
-                                                        "number", 
+                                                        "number",
                                                         "graphId"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
-                                                }, 
+                                                },
                                                 {
                                                     "properties": {
                                                         "config": {
-                                                            "additionalProperties": true, 
+                                                            "additionalProperties": true,
                                                             "type": "object"
-                                                        }, 
+                                                        },
                                                         "decoder": {
-                                                            "description": "Path to a javascript module to implement the decoding functionality.", 
+                                                            "description": "Path to a javascript module to implement the decoding functionality.",
                                                             "type": "string"
-                                                        }, 
+                                                        },
                                                         "number": {
-                                                            "description": "ITM Port Number", 
-                                                            "maximum": 31, 
-                                                            "minimum": 0, 
+                                                            "description": "ITM Port Number",
+                                                            "maximum": 31,
+                                                            "minimum": 0,
                                                             "type": "number"
-                                                        }, 
+                                                        },
                                                         "type": {
                                                             "enum": [
                                                                 "advanced"
-                                                            ], 
+                                                            ],
                                                             "type": "string"
                                                         }
-                                                    }, 
+                                                    },
                                                     "required": [
-                                                        "number", 
+                                                        "number",
                                                         "decoder"
-                                                    ], 
+                                                    ],
                                                     "type": "object"
                                                 }
                                             ]
-                                        }, 
+                                        },
                                         "type": "array"
-                                    }, 
+                                    },
                                     "swoFrequency": {
-                                        "default": 0, 
-                                        "description": "SWO frequency in Hz; 0 will attempt to automatically calculate.", 
+                                        "default": 0,
+                                        "description": "SWO frequency in Hz; 0 will attempt to automatically calculate.",
                                         "type": "number"
                                     }
-                                }, 
-                                "required": [], 
+                                },
+                                "required": [],
                                 "type": "object"
                             }
-                        }, 
+                        },
                         "required": [
-                            "executable", 
+                            "executable",
                             "device"
                         ]
                     }
-                }, 
+                },
                 "configurationSnippets": [
                     {
                         "body": {
-                            "cwd": "^\"\\${workspaceRoot}\"", 
-                            "executable": "${1:./bin/executable.elf}", 
-                            "name": "${6:Debug Microcontroller}", 
-                            "request": "launch", 
+                            "cwd": "^\"\\${workspaceRoot}\"",
+                            "executable": "${1:./bin/executable.elf}",
+                            "name": "${6:Debug Microcontroller}",
+                            "request": "launch",
                             "type": "jlink-gdb"
-                        }, 
-                        "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + JLink", 
+                        },
+                        "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + JLink",
                         "label": "Cortex Debug: JLink"
                     }
-                ], 
+                ],
                 "enableBreakpointsFor": {
                     "languageIds": [
-                        "c", 
-                        "cpp", 
+                        "c",
+                        "cpp",
                         "asm"
                     ]
-                }, 
-                "extensions": [], 
-                "label": "Cortex Debug: JLink", 
-                "program": "./out/src/jlink.js", 
-                "runtime": "node", 
-                "type": "jlink-gdb", 
+                },
+                "extensions": [],
+                "label": "Cortex Debug: JLink",
+                "program": "./out/src/jlink.js",
+                "runtime": "node",
+                "type": "jlink-gdb",
                 "variables": {}
-            }, 
+            },
+            {
+                "configurationAttributes": {
+                    "launch": {
+                        "properties": {
+                            "cwd": {
+                                "description": "Path of project",
+                                "type": "string"
+                            },
+                            "debugger_args": {
+                                "default": [],
+                                "description": "Additional arguments to pass to GDB",
+                                "type": "array"
+                            },
+                            "executable": {
+                                "description": "Path of executable",
+                                "type": "string"
+                            },
+                            "gdbpath": {
+                                "default": "arm-none-eabi-gdb",
+                                "description": "Path to the gdb executable or the command if in PATH",
+                                "type": "string"
+                            },
+                            "stutilpath": {
+                                "default": "st-util",
+                                "description": "Path to the st-util executable",
+                                "type": "string"
+                            },
+                            "printCalls": {
+                                "default": false,
+                                "description": "Prints all GDB calls to the console",
+                                "type": "boolean"
+                            },
+                            "showDevDebugOutput": {
+                                "default": false,
+                                "description": "Prints all GDB responses to the console",
+                                "type": "boolean"
+                            },
+                            "device": {
+                                "default": "",
+                                "description": "STLink Target Device Identifier",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "executable",
+                            "device"
+                        ]
+                    }
+                },
+                "configurationSnippets": [
+                    {
+                        "body": {
+                            "type": "stlink-gdb",
+                            "request": "launch",
+                            "name": "${6:Debug Microcontroller}",
+                            "cwd": "^\"\\${workspaceRoot}\"",
+                            "executable": "${1:./bin/executable.elf}",
+                            "stutilpath": "${2:st-util}",
+                            "gdbpath": "${3:arm-none-eabi-gdb}"
+                        },
+                        "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + STLink",
+                        "label": "Cortex Debug: STLink"
+                    }
+                ],
+                "enableBreakpointsFor": {
+                    "languageIds": [
+                        "c",
+                        "cpp",
+                        "asm",
+                        "arm"
+                    ]
+                },
+                "extensions": [],
+                "label": "Cortex Debug: STLink",
+                "program": "./out/src/stlink.js",
+                "runtime": "node",
+                "type": "stlink-gdb",
+                "variables": {}
+            },
             {
                 "configurationAttributes": {
                     "attach": {
                         "properties": {
                             "boardId": {
-                                "description": "Connect to board by board id. Only needed if multiple PyOCD compatible boards are connected.", 
+                                "description": "Connect to board by board id. Only needed if multiple PyOCD compatible boards are connected.",
                                 "type": "string"
-                            }, 
+                            },
                             "cwd": {
-                                "description": "Path of project", 
+                                "description": "Path of project",
                                 "type": "string"
-                            }, 
+                            },
                             "debugger_args": {
-                                "default": [], 
-                                "description": "Additional arguments to pass to GDB", 
+                                "default": [],
+                                "description": "Additional arguments to pass to GDB",
                                 "type": "array"
-                            }, 
+                            },
                             "executable": {
-                                "description": "Path of executable", 
+                                "description": "Path of executable",
                                 "type": "string"
-                            }, 
+                            },
                             "gdbpath": {
-                                "default": "arm-none-eabi-gdb", 
-                                "description": "Path to the gdb executable or the command if in PATH", 
+                                "default": "arm-none-eabi-gdb",
+                                "description": "Path to the gdb executable or the command if in PATH",
                                 "type": "string"
-                            }, 
+                            },
                             "printCalls": {
-                                "default": false, 
-                                "description": "Prints all GDB calls to the console", 
+                                "default": false,
+                                "description": "Prints all GDB calls to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "pyocdPath": {
-                                "default": "pyocd-gdbserver", 
-                                "description": "Path to the pyocd-gdbserver executable", 
+                                "default": "pyocd-gdbserver",
+                                "description": "Path to the pyocd-gdbserver executable",
                                 "type": "string"
-                            }, 
+                            },
                             "showDevDebugOutput": {
-                                "default": false, 
-                                "description": "Prints all GDB responses to the console", 
+                                "default": false,
+                                "description": "Prints all GDB responses to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "svdFile": {
-                                "default": null, 
-                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.", 
+                                "default": null,
+                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.",
                                 "type": "string"
-                            }, 
+                            },
                             "target": {
-                                "description": "PyOCD Target identifier. Needed if debugging custom hardware; not needed for official MBed boards.", 
+                                "description": "PyOCD Target identifier. Needed if debugging custom hardware; not needed for official MBed boards.",
                                 "enum": [
-                                    "kl25z", 
-                                    "kl26z", 
-                                    "lpc824", 
-                                    "k82f25615", 
-                                    "lpc11xx_32", 
-                                    "kinetis", 
-                                    "lpc800", 
-                                    "lpc4088qsb", 
-                                    "maxwsnenv", 
-                                    "kl05z", 
-                                    "k64f", 
-                                    "lpc1768", 
-                                    "lpc4088", 
-                                    "lpc4330", 
-                                    "max32600mbed", 
-                                    "k66f18", 
-                                    "w7500", 
-                                    "ke18f16", 
-                                    "k22f", 
-                                    "lpc4088dm", 
-                                    "ke15z7", 
-                                    "kv11z7", 
-                                    "nrf51", 
-                                    "nrf52", 
-                                    "kv10z7", 
-                                    "k20d50m", 
-                                    "kl46z", 
-                                    "stm32f103rc", 
-                                    "kl27z4", 
-                                    "kw40z4", 
-                                    "cortex_m", 
-                                    "lpc11u24", 
-                                    "stm32f051", 
-                                    "kl02z", 
-                                    "ncs36510", 
-                                    "kl28z", 
-                                    "kl43z4", 
+                                    "kl25z",
+                                    "kl26z",
+                                    "lpc824",
+                                    "k82f25615",
+                                    "lpc11xx_32",
+                                    "kinetis",
+                                    "lpc800",
+                                    "lpc4088qsb",
+                                    "maxwsnenv",
+                                    "kl05z",
+                                    "k64f",
+                                    "lpc1768",
+                                    "lpc4088",
+                                    "lpc4330",
+                                    "max32600mbed",
+                                    "k66f18",
+                                    "w7500",
+                                    "ke18f16",
+                                    "k22f",
+                                    "lpc4088dm",
+                                    "ke15z7",
+                                    "kv11z7",
+                                    "nrf51",
+                                    "nrf52",
+                                    "kv10z7",
+                                    "k20d50m",
+                                    "kl46z",
+                                    "stm32f103rc",
+                                    "kl27z4",
+                                    "kw40z4",
+                                    "cortex_m",
+                                    "lpc11u24",
+                                    "stm32f051",
+                                    "kl02z",
+                                    "ncs36510",
+                                    "kl28z",
+                                    "kl43z4",
                                     "kw01z4"
-                                ], 
+                                ],
                                 "type": "string"
                             }
-                        }, 
+                        },
                         "required": [
                             "executable"
                         ]
-                    }, 
+                    },
                     "launch": {
                         "properties": {
                             "boardId": {
-                                "description": "Connect to board by board id. Only needed if multiple PyOCD compatible boards are connected.", 
+                                "description": "Connect to board by board id. Only needed if multiple PyOCD compatible boards are connected.",
                                 "type": "string"
-                            }, 
+                            },
                             "cwd": {
-                                "description": "Path of project", 
+                                "description": "Path of project",
                                 "type": "string"
-                            }, 
+                            },
                             "debugger_args": {
-                                "default": [], 
-                                "description": "Additional arguments to pass to GDB", 
+                                "default": [],
+                                "description": "Additional arguments to pass to GDB",
                                 "type": "array"
-                            }, 
+                            },
                             "executable": {
-                                "description": "Path of executable", 
+                                "description": "Path of executable",
                                 "type": "string"
-                            }, 
+                            },
                             "gdbpath": {
-                                "default": "arm-none-eabi-gdb", 
-                                "description": "Path to the gdb executable or the command if in PATH", 
+                                "default": "arm-none-eabi-gdb",
+                                "description": "Path to the gdb executable or the command if in PATH",
                                 "type": "string"
-                            }, 
+                            },
                             "printCalls": {
-                                "default": false, 
-                                "description": "Prints all GDB calls to the console", 
+                                "default": false,
+                                "description": "Prints all GDB calls to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "pyocdPath": {
-                                "default": "pyocd-gdbserver", 
-                                "description": "Path to the pyocd-gdbserver executable", 
+                                "default": "pyocd-gdbserver",
+                                "description": "Path to the pyocd-gdbserver executable",
                                 "type": "string"
-                            }, 
+                            },
                             "showDevDebugOutput": {
-                                "default": false, 
-                                "description": "Prints all GDB responses to the console", 
+                                "default": false,
+                                "description": "Prints all GDB responses to the console",
                                 "type": "boolean"
-                            }, 
+                            },
                             "svdFile": {
-                                "default": null, 
-                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.", 
+                                "default": null,
+                                "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.",
                                 "type": "string"
-                            }, 
+                            },
                             "target": {
-                                "description": "PyOCD Target identifier. Needed if debugging custom hardware; not needed for official MBed boards.", 
+                                "description": "PyOCD Target identifier. Needed if debugging custom hardware; not needed for official MBed boards.",
                                 "enum": [
-                                    "kl25z", 
-                                    "kl26z", 
-                                    "lpc824", 
-                                    "k82f25615", 
-                                    "lpc11xx_32", 
-                                    "kinetis", 
-                                    "lpc800", 
-                                    "lpc4088qsb", 
-                                    "maxwsnenv", 
-                                    "kl05z", 
-                                    "k64f", 
-                                    "lpc1768", 
-                                    "lpc4088", 
-                                    "lpc4330", 
-                                    "max32600mbed", 
-                                    "k66f18", 
-                                    "w7500", 
-                                    "ke18f16", 
-                                    "k22f", 
-                                    "lpc4088dm", 
-                                    "ke15z7", 
-                                    "kv11z7", 
-                                    "nrf51", 
-                                    "nrf52", 
-                                    "kv10z7", 
-                                    "k20d50m", 
-                                    "kl46z", 
-                                    "stm32f103rc", 
-                                    "kl27z4", 
-                                    "kw40z4", 
-                                    "cortex_m", 
-                                    "lpc11u24", 
-                                    "stm32f051", 
-                                    "kl02z", 
-                                    "ncs36510", 
-                                    "kl28z", 
-                                    "kl43z4", 
+                                    "kl25z",
+                                    "kl26z",
+                                    "lpc824",
+                                    "k82f25615",
+                                    "lpc11xx_32",
+                                    "kinetis",
+                                    "lpc800",
+                                    "lpc4088qsb",
+                                    "maxwsnenv",
+                                    "kl05z",
+                                    "k64f",
+                                    "lpc1768",
+                                    "lpc4088",
+                                    "lpc4330",
+                                    "max32600mbed",
+                                    "k66f18",
+                                    "w7500",
+                                    "ke18f16",
+                                    "k22f",
+                                    "lpc4088dm",
+                                    "ke15z7",
+                                    "kv11z7",
+                                    "nrf51",
+                                    "nrf52",
+                                    "kv10z7",
+                                    "k20d50m",
+                                    "kl46z",
+                                    "stm32f103rc",
+                                    "kl27z4",
+                                    "kw40z4",
+                                    "cortex_m",
+                                    "lpc11u24",
+                                    "stm32f051",
+                                    "kl02z",
+                                    "ncs36510",
+                                    "kl28z",
+                                    "kl43z4",
                                     "kw01z4"
-                                ], 
+                                ],
                                 "type": "string"
                             }
-                        }, 
+                        },
                         "required": [
                             "executable"
                         ]
                     }
-                }, 
+                },
                 "configurationSnippets": [
                     {
                         "body": {
-                            "cwd": "^\"\\${workspaceRoot}\"", 
-                            "executable": "${1:./bin/executable.elf}", 
-                            "name": "${6:Debug Microcontroller}", 
-                            "request": "launch", 
+                            "cwd": "^\"\\${workspaceRoot}\"",
+                            "executable": "${1:./bin/executable.elf}",
+                            "name": "${6:Debug Microcontroller}",
+                            "request": "launch",
                             "type": "pyocd-gdb"
-                        }, 
-                        "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + PyOCD", 
+                        },
+                        "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + PyOCD",
                         "label": "Cortex Debug: PyOCD"
                     }
-                ], 
+                ],
                 "enableBreakpointsFor": {
                     "languageIds": [
-                        "c", 
-                        "cpp", 
+                        "c",
+                        "cpp",
                         "asm"
                     ]
-                }, 
-                "extensions": [], 
-                "label": "Cortex Debug: PyOCD", 
-                "program": "./out/src/pyocd.js", 
-                "runtime": "node", 
-                "type": "pyocd-gdb", 
+                },
+                "extensions": [],
+                "label": "Cortex Debug: PyOCD",
+                "program": "./out/src/pyocd.js",
+                "runtime": "node",
+                "type": "pyocd-gdb",
                 "variables": {}
             }
-        ], 
+        ],
         "menus": {
             "commandPalette": [
                 {
-                    "command": "cortexPeripherals.updateNode", 
+                    "command": "cortexPeripherals.updateNode",
                     "when": "false"
-                }, 
+                },
                 {
-                    "command": "cortexPeripherals.selectedNode", 
+                    "command": "cortexPeripherals.selectedNode",
                     "when": "false"
-                }, 
+                },
                 {
-                    "command": "marus25.cortex-debug-openocd.examineMemory", 
+                    "command": "marus25.cortex-debug-openocd.examineMemory",
                     "when": "debugType == openocd-gdb"
-                }, 
+                },
                 {
-                    "command": "marus25.cortex-debug-jlink.examineMemory", 
+                    "command": "marus25.cortex-debug-jlink.examineMemory",
                     "when": "debugType == jlink-gdb"
-                }, 
+                },
                 {
-                    "command": "marus25.cortex-debug-pyocd.examineMemory", 
+                    "command": "marus25.cortex-debug-stlink.examineMemory",
+                    "when": "debugType == stlink-gdb"
+                },
+                {
+                    "command": "marus25.cortex-debug-pyocd.examineMemory",
                     "when": "debugType == pyocd-gdb"
                 }
-            ], 
+            ],
             "view/item/context": [
                 {
-                    "command": "cortexPeripherals.updateNode", 
+                    "command": "cortexPeripherals.updateNode",
                     "when": "view == cortexPeripherals && viewItem == field"
-                }, 
+                },
                 {
-                    "command": "cortexPeripherals.updateNode", 
+                    "command": "cortexPeripherals.updateNode",
                     "when": "view == cortexPeripherals && viewItem == registerRW"
-                }, 
+                },
                 {
-                    "command": "cortexPeripherals.updateNode", 
+                    "command": "cortexPeripherals.updateNode",
                     "when": "view == cortexPeripherals && viewItem == registerWO"
                 }
-            ], 
+            ],
             "view/title": []
-        }, 
+        },
         "views": {
             "debug": [
                 {
-                    "id": "cortexPeripherals-jlink", 
-                    "name": "Cortex Peripherals", 
+                    "id": "cortexPeripherals-jlink",
+                    "name": "Cortex Peripherals",
                     "when": "debugType == jlink-gdb"
-                }, 
+                },
                 {
-                    "id": "cortexRegisters-jlink", 
-                    "name": "Cortex Registers", 
+                    "id": "cortexRegisters-jlink",
+                    "name": "Cortex Registers",
                     "when": "debugType == jlink-gdb"
-                }, 
+                },
                 {
-                    "id": "cortexPeripherals-openocd", 
-                    "name": "Cortex Peripherals", 
+                    "id": "cortexPeripherals-stlink",
+                    "name": "Cortex Peripherals",
+                    "when": "debugType == stlink-gdb"
+                },
+                {
+                    "id": "cortexRegisters-stlink",
+                    "name": "Cortex Registers",
+                    "when": "debugType == stlink-gdb"
+                },
+                {
+                    "id": "cortexPeripherals-openocd",
+                    "name": "Cortex Peripherals",
                     "when": "debugType == openocd-gdb"
-                }, 
+                },
                 {
-                    "id": "cortexRegisters-openocd", 
-                    "name": "Cortex Registers", 
+                    "id": "cortexRegisters-openocd",
+                    "name": "Cortex Registers",
                     "when": "debugType == openocd-gdb"
-                }, 
+                },
                 {
-                    "id": "cortexPeripherals-pyocd", 
-                    "name": "Cortex Peripherals", 
+                    "id": "cortexPeripherals-pyocd",
+                    "name": "Cortex Peripherals",
                     "when": "debugType == pyocd-gdb"
-                }, 
+                },
                 {
-                    "id": "cortexRegisters-pyocd", 
-                    "name": "Cortex Registers", 
+                    "id": "cortexRegisters-pyocd",
+                    "name": "Cortex Registers",
                     "when": "debugType == pyocd-gdb"
                 }
             ]
         }
-    }, 
+    },
     "dependencies": {
-        "binary-parser": "^1.3.0", 
-        "cbarrick-circular-buffer": "^1.2.3", 
-        "portastic": "^1.0.1", 
-        "protobufjs": "~6.8.4", 
-        "tmp": "0.0.33", 
-        "vscode-debugadapter": "^1.16.0", 
-        "vscode-debugprotocol": "^1.16.0", 
-        "vscode-extension-telemetry": "0.0.10", 
-        "ws": "^3.3.2", 
+        "binary-parser": "^1.3.0",
+        "cbarrick-circular-buffer": "^1.2.3",
+        "portastic": "^1.0.1",
+        "protobufjs": "~6.8.4",
+        "tmp": "0.0.33",
+        "vscode-debugadapter": "^1.16.0",
+        "vscode-debugprotocol": "^1.16.0",
+        "vscode-extension-telemetry": "0.0.10",
+        "ws": "^3.3.2",
         "xml2js": "^0.4.19"
-    }, 
-    "description": "ARM Cortex-M GDB Debugger support for VSCode", 
+    },
+    "description": "ARM Cortex-M GDB Debugger support for VSCode",
     "devDependencies": {
-        "@types/mocha": "^2.2.39", 
-        "@types/node": "^7.0.5", 
-        "mocha": "^3.2.0", 
-        "typescript": "^2.1.6", 
+        "@types/mocha": "^2.2.39",
+        "@types/node": "^7.0.5",
+        "mocha": "^3.2.0",
+        "typescript": "^2.1.6",
         "vscode": "^1.0.0"
-    }, 
-    "displayName": "Cortex-Debug", 
+    },
+    "displayName": "Cortex-Debug",
     "engines": {
         "vscode": "^1.18.0"
-    }, 
-    "icon": "images/icon.png", 
+    },
+    "icon": "images/icon.png",
     "keywords": [
-        "cortex-m", 
-        "gdb", 
-        "debug", 
+        "cortex-m",
+        "gdb",
+        "debug",
         "embedded"
-    ], 
-    "main": "./out/src/frontend/extension", 
-    "name": "cortex-debug", 
-    "preview": true, 
-    "publisher": "marus25", 
+    ],
+    "main": "./out/src/frontend/extension",
+    "name": "cortex-debug",
+    "preview": true,
+    "publisher": "marus25",
     "repository": {
-        "type": "git", 
+        "type": "git",
         "url": "https://github.com/Marus/cortex-debug.git"
-    }, 
+    },
     "scripts": {
         "watch": "tsc -watch -p ./",
         "compile": "tsc -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install", 
         "vscode:prepublish": "tsc -p ./"
-    }, 
+    },
     "version": "0.1.8"
 }

--- a/package.json
+++ b/package.json
@@ -1805,7 +1805,8 @@
         "url": "https://github.com/Marus/cortex-debug.git"
     }, 
     "scripts": {
-        "compile": "tsc -watch -p ./", 
+        "watch": "tsc -watch -p ./",
+        "compile": "tsc -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install", 
         "vscode:prepublish": "tsc -p ./"
     }, 

--- a/package.json
+++ b/package.json
@@ -1543,6 +1543,18 @@
                         "label": "Cortex Debug: STLink"
                     }
                 ],
+                "initialConfigurations": [
+                    {
+                        "type": "stlink-gdb",
+                        "request": "launch",
+                        "name": "Cortex Debug",
+                        "cwd": "${workspaceRoot}",
+                        "executable": "./bin/executable.elf",
+                        "stutilpath": "st-util",
+                        "gdbpath": "arm-none-eabi-gdb",
+                        "device": ""
+                    }
+                ],
                 "enableBreakpointsFor": {
                     "languageIds": [
                         "c",

--- a/src/backend/stlink.ts
+++ b/src/backend/stlink.ts
@@ -1,0 +1,89 @@
+import * as ChildProcess from 'child_process';
+import { EventEmitter } from "events";
+import * as portastic from 'portastic';
+
+export class STLink extends EventEmitter {
+	private process: any;
+	private buffer: string;
+	private errbuffer: string;
+	private initSent: boolean;
+
+	constructor(public application: string, public gdb_port: number) {
+		super();
+
+		this.initSent = false;
+		this.buffer = "";
+		this.errbuffer = "";
+	}
+
+	init(): Thenable<any> {
+		return new Promise((resolve, reject) => {
+			let args = ["-p", this.gdb_port.toString(), '-v'];
+
+			this.process = ChildProcess.spawn(this.application, args, {});
+			this.process.stdout.on('data', this.stdout.bind(this));
+			this.process.stderr.on('data', this.stderr.bind(this));
+			this.process.on("exit", (() => { this.emit("quit"); }).bind(this));
+			this.process.on("error", ((err) => { this.emit("launcherror", err); }).bind(this));
+			setTimeout(resolve, 50);
+		});
+	}
+
+	exit() : void {
+		this.process.kill();
+	}
+
+	error() : void {
+		
+	}
+
+	close(code, signal) {
+		console.log('Closed st-util with ', code, signal);
+	}
+
+	stdout(data) {
+		if (typeof data =="string")
+			this.buffer += data;
+		else
+			this.buffer += data.toString("utf8");
+		
+		let end = this.buffer.lastIndexOf('\n');
+		if (end != -1) {
+			this.onOutput(this.buffer.substr(0, end));
+			this.buffer = this.buffer.substr(end + 1);
+		}
+	}
+
+	stderr(data) {
+		if (typeof data == "string")
+			this.errbuffer += data;
+		else
+			this.errbuffer += data.toString("utf8");
+
+		// st-util prints information to stderr rather than stdout
+		if (this.errbuffer.indexOf(`Listening at *:${this.gdb_port}...`) !== -1) {
+			if (!this.initSent) {
+				this.emit('stlink-init');
+				this.initSent = true;
+			}
+		}
+		
+		let end = this.errbuffer.lastIndexOf('\n');
+		if(end != -1) {
+			this.onOutput(this.errbuffer.substr(0, end));
+			this.errbuffer = this.errbuffer.substr(end + 1);
+		}
+	}
+
+	stop() {
+		this.process.kill();
+	}
+
+	onOutput(text: string) {
+		this.emit('stlink-output', text);
+	}
+
+	onErrOutput(text: string) {
+		this.emit('stlink-stderr', text);
+	}
+}

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -56,13 +56,16 @@ class CortexDebugExtension {
 		context.subscriptions.push(vscode.commands.registerCommand('cortexPeripherals.updateNode', this.peripheralsUpdateNode.bind(this)));
 		context.subscriptions.push(vscode.commands.registerCommand('cortexPeripherals.selectedNode', this.peripheralsSelectedNode.bind(this)));
 		context.subscriptions.push(vscode.commands.registerCommand('marus25.cortex-debug-jlink.examineMemory', this.examineMemory.bind(this)));
+		context.subscriptions.push(vscode.commands.registerCommand('marus25.cortex-debug-stlink.examineMemory', this.examineMemory.bind(this)));
 		context.subscriptions.push(vscode.commands.registerCommand('marus25.cortex-debug-openocd.examineMemory', this.examineMemory.bind(this)));
 		context.subscriptions.push(vscode.commands.registerCommand('marus25.cortex-debug-pyocd.examineMemory', this.examineMemory.bind(this)));
 
 		context.subscriptions.push(vscode.window.registerTreeDataProvider('cortexPeripherals-jlink', this.peripheralProvider));
+		context.subscriptions.push(vscode.window.registerTreeDataProvider('cortexPeripherals-stlink', this.peripheralProvider));
 		context.subscriptions.push(vscode.window.registerTreeDataProvider('cortexPeripherals-openocd', this.peripheralProvider));
 		context.subscriptions.push(vscode.window.registerTreeDataProvider('cortexPeripherals-pyocd', this.peripheralProvider));
 		context.subscriptions.push(vscode.window.registerTreeDataProvider('cortexRegisters-jlink', this.registerProvider));	
+		context.subscriptions.push(vscode.window.registerTreeDataProvider('cortexRegisters-stlink', this.registerProvider));
 		context.subscriptions.push(vscode.window.registerTreeDataProvider('cortexRegisters-openocd', this.registerProvider));
 		context.subscriptions.push(vscode.window.registerTreeDataProvider('cortexRegisters-pyocd', this.registerProvider));
 
@@ -73,7 +76,7 @@ class CortexDebugExtension {
 
 	getSVDFile(device: string): string {
 		let entry = this.SVDDirectory.find(de => de.expression.test(device));
-		return entry ? entry.path : null;	
+		return entry ? entry.path : null;
 	}
 
 	examineMemory() {
@@ -181,7 +184,7 @@ class CortexDebugExtension {
 				graphing: (args.GraphConfig && args.GraphConfig.length > 0) ? 'enabled' : 'disabled'
 			};
 
-			if (args.type == 'jlink-gdb') {
+			if (args.type == 'jlink-gdb' || args.type == 'stlink-gdb') {
 				info['device'] = args.device;
 			}
 

--- a/src/frontend/registers.ts
+++ b/src/frontend/registers.ts
@@ -46,7 +46,7 @@ export class RegisterNode extends BaseNode {
 		super(RecordType.Register);
 		this.name = this.name;
 
-		if(name.toUpperCase() === 'XPSR') {
+		if(name.toUpperCase() === 'XPSR' || name.toUpperCase() === 'CPSR') {
 			this.fields = [
 				new FieldNode('Negative Flag (N)', 31, 1, this),
 				new FieldNode('Zero Flag (Z)', 30, 1, this),

--- a/src/jlink.ts
+++ b/src/jlink.ts
@@ -224,7 +224,7 @@ class JLinkGDBDebugSession extends GDBDebugSession {
 		switch(command) {
 			case 'get-arguments':
 				response.body = {
-					type: 'jlink',
+					type: 'jlink-gdb',
 					GDBPort: this.gdbPort,
 					SWOPort: this.swoPort,
 					ConsolePort: this.consolePort,

--- a/src/stlink.ts
+++ b/src/stlink.ts
@@ -1,0 +1,215 @@
+import { GDBDebugSession } from './gdb';
+import { DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent, Thread, StackFrame, Scope, Source, Handles, Event } from 'vscode-debugadapter';
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { STLink } from './backend/stlink';
+import { MI2 } from "./backend/mi2/mi2";
+import { AdapterOutputEvent, SWOConfigureEvent } from './common';
+import * as portastic from 'portastic';
+import * as os from 'os';
+import { TelemetryEvent } from './common';
+
+export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArguments {
+	gdbpath: string;
+	executable: string;
+	cwd: string;
+	device: string;
+	stutilpath: string;
+	debugger_args: string[];
+	showDevDebugOutput: boolean;
+	svdFile: string;
+}
+
+class STLinkGDBDebugSession extends GDBDebugSession {
+	protected stutil : STLink;
+	private args: ConfigurationArguments;
+	private gdbPort: number;
+	private consolePort: number;
+
+	protected launchRequest(response: DebugProtocol.LaunchResponse, args: ConfigurationArguments): void {
+		this.args = args;
+		this.processLaunchAttachRequest(response, args, false);
+	}
+	
+	private processLaunchAttachRequest(response: DebugProtocol.LaunchResponse, args: ConfigurationArguments, attach: boolean) {
+		this.quit = false;
+		this.attached = false;
+		this.started = false;
+		this.crashed = false;
+		this.debugReady = false;
+		
+		portastic.find({ min: 50000, max: 52000, retrieve: 2 }).then(ports => {
+			this.gdbPort = ports[0];
+			this.consolePort = ports[1];
+
+			let defaultExecutable = 'st-util';	// the name of the program is st-util rather than STLink
+			let defaultGDBExecutable = 'arm-none-eabi-gdb';
+			if(os.platform() == 'win32') {
+				defaultExecutable = 'st-util.exe';
+				defaultGDBExecutable = 'arm-none-eabi-gdb.exe';
+			}
+
+			this.stutil = new STLink(args.stutilpath || defaultExecutable, this.gdbPort);
+			this.stutil.on('stutil-output', this.handleSTUtilOutput.bind(this));
+			this.stutil.on('stutil-stderr', this.handleSTUtilErrorOutput.bind(this));
+			
+			this.stutil.on("launcherror", (err) => {
+				this.sendErrorResponse(response, 103, `Failed to launch STLink GDB Server: ${err.toString()}`);
+			});
+			this.stutil.on("quit", () => {
+				if (this.started) {
+					this.quitEvent.bind(this)
+				}
+				else {
+					this.sendErrorResponse(response, 103, `STLink GDB Server Quit Unexpectedly. See Adapter Output for more details.`);
+					this.sendErrorResponse(response, 103, `STLink GDB Server Quit Unexpectedly.`);
+				}
+			});
+
+			let timeout = null;
+
+			this.stutil.on('stlink-init', () => {
+				if(timeout) {
+					clearTimeout(timeout);
+					timeout = null;
+				}
+
+				this.miDebugger = new MI2(args.gdbpath || defaultGDBExecutable, ["-q", "--interpreter=mi2"], args.debugger_args);
+				this.initDebugger();
+	
+				this.miDebugger.printCalls = !!args.showDevDebugOutput;
+				this.miDebugger.debugOutput = !!args.showDevDebugOutput
+
+				let commands = attach ? this.attachCommands(this.gdbPort, args) : this.launchCommands(this.gdbPort, args);
+				
+				this.miDebugger.connect(args.cwd, args.executable, commands).then(() => {
+					setTimeout(() => {
+						this.miDebugger.emit("ui-break-done");
+					}, 50);
+	
+					this.miDebugger.start().then(() => {
+						this.started = true;
+						this.sendResponse(response);
+						
+						if (this.crashed)
+							this.handlePause(undefined);
+					}, err => {
+						this.sendErrorResponse(response, 100, `Failed to launch GDB: ${err.toString()}`);
+						this.sendEvent(new TelemetryEvent('error-launching-gdb', { error: err.toString() }, {}));
+					});
+				}, err => {
+					this.sendErrorResponse(response, 103, `Failed to launch GDB: ${err.toString()}`);
+					this.sendEvent(new TelemetryEvent('error-launching-gdb', { error: err.toString() }, {}));
+				});
+			});
+			
+			this.stutil.init().then(_ => {}, _ => {});
+			
+			timeout = setTimeout(() => {
+				this.stutil.exit();
+				this.sendEvent(new TelemetryEvent('error-launching-stlink', { error: `Failed to launch STLink Server: Timeout.` }, {}));
+				this.sendErrorResponse(response, 103, `Failed to launch STLink Server: Timeout.`);
+			}, 10000);
+		}, err => {
+			this.sendEvent(new TelemetryEvent('error-launching-stlink', { error: err.toString() }, {}));
+			this.sendErrorResponse(response, 103, `Failed to launch STLink Server: ${err.toString()}`);
+		});
+	}
+
+	protected launchCommands(gdbport: number, args: ConfigurationArguments): string[] {
+		let commands = [
+			`target-select extended-remote localhost:${gdbport}`,
+			'interpreter-exec console "monitor halt"',
+			'interpreter-exec console "monitor reset"',
+			'target-download',
+			'interpreter-exec console "monitor reset"',
+			'enable-pretty-printing'
+		];
+
+		return commands;
+	}
+
+	protected attachCommands(gdbport: number, args: ConfigurationArguments): string[] {
+		let commands = [
+			`target-select extended-remote localhost:${gdbport}`,
+			'interpreter-exec console "monitor halt"',
+			'enable-pretty-printing'
+		];
+
+		return commands;
+	}
+
+	protected restartCommands(): string[] {
+		return [
+			'exec-interrupt',
+			'interpreter-exec console "monitor halt"',
+			'interpreter-exec console "monitor reset"',
+			'exec-step-instruction'
+		];
+	}
+
+	protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void {
+		if(this.miDebugger) {
+			if (this.attached)
+				this.miDebugger.detach();
+			else
+				this.miDebugger.stop();
+		}
+		if(this.commandServer) {
+			this.commandServer.close();
+			this.commandServer = undefined;
+		}
+
+		try { this.stutil.stop(); }
+		catch(e) {}
+
+		this.sendResponse(response);
+	}
+
+	protected restartRequest(response: DebugProtocol.RestartResponse, args: DebugProtocol.RestartArguments): void {
+		let commands = this.restartCommands();
+
+		this.miDebugger.restart(commands).then(done => {
+			this.sendResponse(response);
+		}, msg => {
+			this.sendErrorResponse(response, 6, `Could not restart: ${msg}`);
+		})
+	}
+
+	protected handleSTUtilOutput(output) {
+		this.sendEvent(new AdapterOutputEvent(output, 'out'));
+	}
+
+	protected handleSTUtilErrorOutput(output) {
+		this.sendEvent(new AdapterOutputEvent(output, 'err'));
+	}
+
+	protected customRequest(command: string, response: DebugProtocol.Response, args: any): void {
+		switch(command) {
+			case 'get-arguments':
+				response.body = {
+					type: 'stlink-gdb',
+					device: this.args.device,
+					GDBPort: this.gdbPort,
+					ConsolePort: this.consolePort,
+					SVDFile: this.args.svdFile,
+					SWOConfig: { enabled: false, cpuFrequency: 0, swoFrequency: 0 },
+					GraphConfig: []
+				};
+				this.sendResponse(response);
+				break;
+			default:
+				super.customRequest(command, response, args);
+				break;
+		}
+	}
+
+	private calculatePortMask(configuration: any[]) {
+		let mask: number = 0;
+		configuration.forEach(c => {
+			mask = (mask | (1 << c.number)) >>> 0;
+		});
+		return mask;
+	}
+}
+
+DebugSession.run(STLinkGDBDebugSession);


### PR DESCRIPTION
This pull request adds support for ST-Link tools.
It:
 - adds a debugger type stlink-gdb
 - provides STLink implementation based on JLink
 - adds device name to SVD file mapping for STM32L4x6 MCUs

Current limitations:
 - SWO is not supported
 - launch only

It also fixes some problem with npm script and launch config, see 76fb672.