### PR TITLE
Syntax highlighting to memory view

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,15 @@
                 "extensions": [
                     ".cdasm"
                 ]
+            },
+            {
+                "id": "cortex-debug.memoryview",
+                "aliases": [
+                    "Cortex-Debug Memory View"
+                ],
+                "extensions": [
+                    ".cdmem"
+                ]
             }
         ],
         "grammars": [
@@ -90,6 +99,11 @@
                 "language": "cortex-debug.disassembly",
                 "scopeName": "source.cortex-debug-disassembly",
                 "path": "./syntaxes/cortex-debug-disassembly.json"
+            },
+            {
+                "language": "cortex-debug.memoryview",
+                "scopeName": "source.cortex-debug-memoryview",
+                "path": "./syntaxes/cortex-debug-memoryview.json"
             }
         ],
         "debuggers": [

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -289,9 +289,12 @@ class CortexDebugExtension {
 
 						Reporting.sendEvent('examine-memory', {}, {});
 						let timestamp = new Date().getTime();
-						vscode.workspace.openTextDocument(`examinememory:///Memory%20[${address}+${length}].hexdump?address=${address}&length=${length}&timestamp=${timestamp}`).then((doc) => {
-							vscode.window.showTextDocument(doc, { viewColumn: 2 })	;
-						})
+						vscode.workspace.openTextDocument(vscode.Uri.parse(`examinememory:///Memory%20[${address}+${length}].hexdump?address=${address}&length=${length}&timestamp=${timestamp}`))
+										.then((doc) => {
+											vscode.window.showTextDocument(doc, { viewColumn: 2 })	;
+										}, (error) => {
+											vscode.window.showErrorMessage(`Failed to examine memory: ${error}`);
+										})
 					},
 					(error) => {
 

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -289,7 +289,7 @@ class CortexDebugExtension {
 
 						Reporting.sendEvent('examine-memory', {}, {});
 						let timestamp = new Date().getTime();
-						vscode.workspace.openTextDocument(vscode.Uri.parse(`examinememory:///Memory%20[${address}+${length}].hexdump?address=${address}&length=${length}&timestamp=${timestamp}`))
+						vscode.workspace.openTextDocument(vscode.Uri.parse(`examinememory:///Memory%20[${address}+${length}].cdmem?address=${address}&length=${length}&timestamp=${timestamp}`))
 										.then((doc) => {
 											vscode.window.showTextDocument(doc, { viewColumn: 2 })	;
 										}, (error) => {

--- a/src/frontend/memory_content_provider.ts
+++ b/src/frontend/memory_content_provider.ts
@@ -23,7 +23,7 @@ export class MemoryContentProvider implements vscode.TextDocumentContentProvider
 
 				let lineend = '';
 
-				for (let i = 0; i < offset; i++) { output += '   '; lineend += '  '; }
+				for (let i = 0; i < offset; i++) { output += '   '; lineend += ' '; }
 
 				for (let i = 0; i < length; i++) {
 					let byte = bytes[i];

--- a/syntaxes/cortex-debug-memoryview.json
+++ b/syntaxes/cortex-debug-memoryview.json
@@ -1,0 +1,21 @@
+{
+    "name": "Cortex-Debug Memory View",
+    "scopeName": "source.cortex-debug-memoryview",
+    "patterns": [
+        {
+            "comment": "Heading",
+            "name": "keyword.header.hex",
+            "match": "^  Offset: 00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F \\t$"
+        },
+        {
+            "comment": "Address",
+            "name": "keyword.address.hex",
+            "match": "^([a-fA-F\\d]{8}:)"
+        },
+        {
+            "comment": "ASCII",
+            "name": "comment.ascii.hex",
+            "match": "  [^\\s]*$"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request adds syntax highlighting to memory view as a first step in polishing the memory view.

- define memory view 'file' name as `.cdmem`;
- add syntax JSON file ported from Hexdump;
- add language and grammar to package.json

Also fixes some bugs, which prevented opening and correct display of memory view. See: 52e63dd & 98581c9 