### PR TITLE
Bug Fix: non-resolved promise

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -26,9 +26,8 @@ export class GDBServer extends EventEmitter {
 				this.process.on('exit', this.onExit.bind(this));
 				this.process.on('error', this.onError.bind(this));
 			}
-			else { // For servers like BMP that are always running directly on the probe
-				resolve();
-			}
+			resolve();
+			// For servers like BMP that are always running directly on the probe
 		});
 	}
 


### PR DESCRIPTION
the promise in `GDBServer.init()` is not resolved in the main branch of `if`.
This causes a time out problem and the server sub-process is terminated.
This bug became apparent in Node v8.9.4, yet works with older version of Node (e.g. `v8.9.1` on my macOS).