### PR TITLE
Added support for powering up the board over BMP

### DIFF
--- a/package.json
+++ b/package.json
@@ -621,6 +621,10 @@
                             "BMPGDBSerialPort": {
                                 "type": "string",
                                 "description": "The serial port for the Black Magic Probe GDB server. On Windows this will be \"COM<num>\", on Linux this will be something similar to /dev/ttyACM0, on OS X something like /dev/cu.usbmodemE2C0C4C6 (do not use tty versions on OS X)"
+                            },
+                            "powerOverBMP": {
+                                "type": "string",
+                                "description": "Power up the board over Black Magic Probe. \"powerOverBMP\" : \"enable\" or \"powerOverBMP\" : \"disable\". If not set it will use the last power state."
                             }
                         },
                         "required": [
@@ -1112,6 +1116,10 @@
                             "BMPGDBSerialPort": {
                                 "type": "string",
                                 "description": "The serial port for the Black Magic Probe GDB server. On Windows this will be \"COM<num>\", on Linux this will be something similar to /dev/ttyACM0, on OS X something like /dev/cu.usbmodemE2C0C4C6 (do not use tty versions on OS X)"
+                            },
+                            "powerOverBMP": {
+                                "type": "string",
+                                "description": "Power up the board over Black Magic Probe. \"powerOverBMP\" : \"enable\" or \"powerOverBMP\" : \"disable\". If not set it will use the last power state."
                             }
                         },
                         "required": [

--- a/src/bmp.ts
+++ b/src/bmp.ts
@@ -31,6 +31,18 @@ export class BMPServerController extends EventEmitter implements GDBServerContro
             `target-select extended-remote ${this.args.BMPGDBSerialPort}`
         ];
 
+        if (this.args.powerOverBMP === 'enable') {
+            commands.push('interpreter-exec console "monitor tpwr enable"');
+            //sleep for 100 ms. MCU need some time to boot up after power up
+            commands.push('interpreter-exec console "shell sleep 0.1"'); 
+        }
+        else if (this.args.powerOverBMP === 'disable'){
+            commands.push('interpreter-exec console "monitor tpwr disable"');
+        }
+        else{
+            //keep last power state (do nothing)
+        }
+
         if (this.args.interface === 'jtag') {
             commands.push('interpreter-exec console "monitor jtag_scan"');
         }

--- a/src/common.ts
+++ b/src/common.ts
@@ -123,6 +123,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
 
     // BMP Specific
     BMPGDBSerialPort: string;
+    powerOverBMP: string;
 
     // Hidden settings - These settings are for advanced configuration and are not exposed in the package.json file
     gdbpath: string;

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -233,6 +233,7 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
 
     private verifyBMPConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration): string {
         if (!config.BMPGDBSerialPort) { return 'A Serial Port for the Black Magic Probe GDB server is required.'; }
+        if (!config.powerOverBMP) { config.powerOverBMP = 'lastState'; }
         if (!config.interface) { config.interface = 'swd'; }
         if (!config.targetId) { config.targetId = 1; }
         


### PR DESCRIPTION
Black Magic Probe has the option to power up the board with the command "monitor tpwr enable". This is the implementation of this option. I use this option on my [Pixracer](https://docs.px4.io/en/flight_controller/pixracer.html)