### PR TITLE
Check if gdb exists to prevent unrelated problems from occuring

### DIFF
--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -182,6 +182,15 @@ export class GDBDebugSession extends DebugSession {
                 gdbExePath = this.args.gdbpath;
             }
 
+            // Check to see if gdb exists.
+            if (fs.existsSync(gdbExePath) === false) {
+                this.sendErrorResponse(
+                    response,
+                    103,
+                    `${this.serverController.name} GDB executable "${gdbExePath}" was not found.\nPlease configure "cortex-debug.armToolchainPath" correctly`
+                );
+            }
+
             this.server = new GDBServer(executable, args, this.serverController.initMatch());
             this.server.on('output', this.handleAdapterOutput.bind(this));
             this.server.on('quit', () => {


### PR DESCRIPTION
This error is to inform the developer they have misconfigured their paths. When GDB fails to launch. a confusing error message shows that suggests OpenOCD is at fault.

in my case, my user settings had:
```json
{
    "cortex-debug.armToolchainPath": "C:\\gnu-arm-none-eabi-7-2018-q2-update",
}
```

instead of 
```json
{
    "cortex-debug.armToolchainPath": "C:\\gnu-arm-none-eabi-7-2018-q2-update\\bin",
}
```