### PR TITLE
Option to show a particular SWO output window during debugger startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -382,6 +382,10 @@
                                                             "description": "A label for the output window.",
                                                             "type": "string"
                                                         },
+                                                        "showOnStartup": {
+                                                            "description": "If true, switches to this output when starting a debug session.",
+                                                            "type": "boolean"
+                                                        },
                                                         "port": {
                                                             "description": "ITM Port Number",
                                                             "maximum": 31,

--- a/src/frontend/swo/common.ts
+++ b/src/frontend/swo/common.ts
@@ -9,6 +9,7 @@ export interface SWOBasicDecoderConfig extends SWODecoderConfig {
 export interface SWOConsoleDecoderConfig extends SWOBasicDecoderConfig {
     label: string;
     encoding: string;
+    showOnStartup: boolean;
 }
 
 export interface SWOBinaryDecoderConfig extends SWOBasicDecoderConfig {

--- a/src/frontend/swo/decoders/console.ts
+++ b/src/frontend/swo/decoders/console.ts
@@ -18,6 +18,10 @@ export class SWOConsoleProcessor implements SWODecoder {
         this.port = config.port;
         this.encoding = config.encoding || 'utf8';
         this.output = vscode.window.createOutputChannel(`SWO: ${config.label || ''} [port: ${this.port}, type: console]`);
+
+        if (config.showOnStartup) {
+            this.output.show(true);
+        }
     }
 
     public softwareEvent(packet: Packet) {


### PR DESCRIPTION
Hi Marcel,

I'd love if you could include the option to show a SWO output window during startup

Thanks,

Stefan