### PR TITLE
Add more PE support

### DIFF
--- a/package.json
+++ b/package.json
@@ -580,7 +580,7 @@
                                 ]
                             },
                             "configFiles": {
-                                "description": "OpenOCD configuration file(s) to load",
+                                "description": "OpenOCD/pegdbserver configuration file(s) to load",
                                 "items": {
                                     "type": "string"
                                 },

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -263,9 +263,9 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
             const configuration = vscode.workspace.getConfiguration('cortex-debug');
             config.serverpath = configuration.PEGDBServerPath;
         }
-        
-        if (config.rtos) {
-            return 'The PE GDB Server does not have support for the rtos option.';
+
+        if (config.configFiles && config.configFiles.length > 1) {
+            return 'Only one pegdbserver Configuration File is allowed.';
         }
 
         if (!config.device) {

--- a/src/pemicro.ts
+++ b/src/pemicro.ts
@@ -82,12 +82,9 @@ export class PEServerController extends EventEmitter implements GDBServerControl
 
         const serverargs = [];
 
-        if (this.args.device) {
-            serverargs.push(`-device=${this.args.device}`);
-		}
-		
 		serverargs.push('-startserver');
 		serverargs.push('-singlesession');
+        serverargs.push(`-device=${this.args.device}`);
         serverargs.push(`-serverport=${gdbport}`);
         
         if (this.args.ipAddress)

--- a/src/pemicro.ts
+++ b/src/pemicro.ts
@@ -86,9 +86,12 @@ export class PEServerController extends EventEmitter implements GDBServerControl
             serverargs.push(`-device=${this.args.device}`);
 		}
 		
-		serverargs.push('-startserver')
-		serverargs.push('-singlesession')
-		serverargs.push(`-serverport=${gdbport}`)
+		serverargs.push('-startserver');
+		serverargs.push('-singlesession');
+        serverargs.push(`-serverport=${gdbport}`);
+        
+        if (this.args.ipAddress)
+            serverargs.push(`-serverip=${this.args.ipAddress}`);
 
         if (this.args.interface) {
             serverargs.push(`-interface=${this.args.interface}`);

--- a/src/pemicro.ts
+++ b/src/pemicro.ts
@@ -93,6 +93,9 @@ export class PEServerController extends EventEmitter implements GDBServerControl
         if (this.args.ipAddress)
             serverargs.push(`-serverip=${this.args.ipAddress}`);
 
+        if (this.args.rtos)
+            serverargs.push(`-kernal=${this.args.rtos}`);
+
         if (this.args.interface) {
             serverargs.push(`-interface=${this.args.interface}`);
         }

--- a/src/pemicro.ts
+++ b/src/pemicro.ts
@@ -49,6 +49,7 @@ export class PEServerController extends EventEmitter implements GDBServerControl
 
     public attachCommands(): string[] {
         const commands = [
+            'interpreter-exec console "monitor halt"',
             'enable-pretty-printing'
         ];
         
@@ -96,6 +97,10 @@ export class PEServerController extends EventEmitter implements GDBServerControl
         if (this.args.interface) {
             serverargs.push(`-interface=${this.args.interface}`);
         }
+
+        if (this.args.configFiles) {
+            serverargs.push(`-configfile=${this.args.configFiles[0]}`);
+        };
         
         console.log(`ServerArgs:${serverargs}`)
 


### PR DESCRIPTION
Adds more support for PE Micro's pegdb_server.console:
- RTOS option
- Server IP address option
- PE configuration files
- Attach to running target

Since it was difficult to find the documentation for PE Micro's configuration file I'll [link it](http://www.pemicro.com/products/product_viewDetails.cfm?product_id=15320151&productTab=3) and provide a sample:

`config.ini`
```
[CWDBG]
Connect=1;"Hotplug"

[STARTUP]
USE_CYCLONEPRO_RELAYS=1;"Provide power to target (Multilink FX only)"
Multilink_PowerDownDelay=250
Multilink_PowerUpDelay=1000
FORCE_MASS_ERASE=0;"Erase all memory before programming"
```
