### PR TITLE
avoid race condition for runToMain feature, also enhance/fix openocd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 out
-./node_modules
+node_modules
 *.vsix
 .vscode-test
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cortex-debug",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/openocd.ts
+++ b/src/openocd.ts
@@ -117,6 +117,8 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
 
         const serverargs = [];
 
+        serverargs.push('-c', `gdb_port ${gdbport}`);
+
         this.args.searchDir.forEach((cs, idx) => {
             serverargs.push('-s', cs);
         });
@@ -135,7 +137,8 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
             serverargs.push('-f', tmpCfgPath);
         }
 
-        const commands = [`gdb_port ${gdbport}`];
+        //const commands = [`gdb_port ${gdbport}`];
+        const commands = [];
 
         if (this.args.swoConfig.enabled) {
             if (os.platform() == 'win32') {
@@ -152,13 +155,21 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
             });
         }
         
-        serverargs.push('-c', commands.join('; '));
+        if (commands.length > 0) {
+            serverargs.push('-c', commands.join('; '));
+        }
 
         return serverargs;
     }
 
     public initMatch(): RegExp {
-        return /Info\s:\s([^\n\.]*)\.cpu([^\n]*)/i;
+        //return /Info\s:\s([^\n\.]*)\.cpu([^\n]*)/i;
+        /*
+        // Following will work with or without the -d flag to openocd or using the tcl
+        // command `debug_level 3`; and we are looking specifically for gdb port(s) opening up
+        // When debug is enabled, you get too many matches looking for the cpu
+        */
+        return /Info\s:[^\n]*Listening on port [0-9]+ for gdb connection/i;
     }
 
     public serverLaunchStarted(): void {

--- a/src/openocd.ts
+++ b/src/openocd.ts
@@ -137,7 +137,6 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
             serverargs.push('-f', tmpCfgPath);
         }
 
-        //const commands = [`gdb_port ${gdbport}`];
         const commands = [];
 
         if (this.args.swoConfig.enabled) {
@@ -163,13 +162,13 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
     }
 
     public initMatch(): RegExp {
-        //return /Info\s:\s([^\n\.]*)\.cpu([^\n]*)/i;
         /*
         // Following will work with or without the -d flag to openocd or using the tcl
         // command `debug_level 3`; and we are looking specifically for gdb port(s) opening up
-        // When debug is enabled, you get too many matches looking for the cpu
+        // When debug is enabled, you get too many matches looking for the cpu. This message
+        // has been there atleast since 2016-12-19
         */
-        return /Info\s:[^\n]*Listening on port [0-9]+ for gdb connection/i;
+        return /Info\s:[^\n]*Listening on port \d+ for gdb connection/i;
     }
 
     public serverLaunchStarted(): void {


### PR DESCRIPTION
Summary of my changes: I am sorry but in the intent of getting my chip/board working for myself and our customers, I tried to figure out and fix things. There are multiple changes here, some may seem unrelated but I could not have tested/debugged without all of those changes. New to git, your awesome project and I apologize for breaching any protocol; please let me know if I did.

File: src/gdb.ts
- Fixed the race condition between runToMain feature and finishing VSCode debug configuration which includes setting/finalizing of breakpoints. [Issue 147](https://github.com/Marus/cortex-debug/issues/147)
- Added a debug message letting users know exactly what command line was being used to launch a server, I was having issues with PyOCD and OpenOCD. JLink prints it's own.

File: src/openocd.ts
- We have to set the gdb_port before any config scripts are run. Some config scripts run the 'init' function and once that is executed, you cannot change/reset the gdb_port. the gdb_port command just sets a global variable that is not used until 'init' is called. After that, openocd will throw an exception and quit. [Issue 149](https://github.com/Marus/cortex-debug/issues/149)
- initMatch regexp does not work if you enable openocd debug mode, or may match things not related to gdb port opening. I think I found a bit more robust way. [Issue 150
](https://github.com/Marus/cortex-debug/issues/150)

File: .gitignore
- Feel free to ignore :-). I was getting 3000+ changes reported by git. They were all in the node_modules directories, so I changed it from current dir to global scope. If no one else was having a problem with this, not sure what is wrong with my setup. I just did an 'npm install' after cloning and that's it. Perhaps I should not have done that and follow another workflow?

Feel free to PM me.
