### PR TITLE
Allow toolchain prefix to be configured per launch configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -759,6 +759,11 @@
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
                                 "type": "string"
                             },
+                            "toolchainPrefix": {
+                                "default": null,
+                                "description": "This setting can be used to override the toolchainPrefix user setting for a particular launch configuration.",
+                                "type": "string"
+                            },
                             "executable": {
                                 "description": "Path of executable",
                                 "type": "string"

--- a/package.json
+++ b/package.json
@@ -253,6 +253,11 @@
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
                                 "type": "string"
                             },
+                            "toolchainPrefix": {
+                                "default": null,
+                                "description": "This setting can be used to override the toolchainPrefix user setting for a particular launch configuration.",
+                                "type": "string"
+                            },
                             "executable": {
                                 "description": "Path of executable",
                                 "type": "string"

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -89,7 +89,9 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
         if (!config.toolchainPath) {
             config.toolchainPath = configuration.armToolchainPath;
         }
-        config.toolchainPrefix = configuration.armToolchainPrefix || 'arm-none-eabi';
+        if (!config.toolchainPrefix) {
+            config.toolchainPrefix = configuration.armToolchainPrefix || 'arm-none-eabi';
+        }
         
         config.extensionPath = this.context.extensionPath;
         if (os.platform() === 'win32') {


### PR DESCRIPTION
This is currently exposed in the user/workspace configuration, but we have projects that use multiple toolchains in the same workspace because there are multiple build targets. This would help us by allowing us to select a different toolchain variant per launch configuration.

Before you ask, the reason that we even need the prefix is that we're using `cortext-debug` for both ARM Cortex microcontrollers and non-ARM microcontrollers. If we ignore the intellisense warnings in the configuration and smooth over the prefix problems this works as long as we name our alternative toolchains "correctly". I know this is a weird use case but `cortex-debug` is much better than any of the alternatives and being able to use it with our strange project configurations without hacks would be much appreciated.