### PR TITLE
Minor changes to port-scanner, better handle platform specific overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode-test
 .DS_Store
 .sass-cache
+/dist

--- a/package.json
+++ b/package.json
@@ -253,6 +253,11 @@
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
                                 "type": "string"
                             },
+                            "serverpath": {
+                                "default": null,
+                                "description": "This setting can be used to override the gdb-server path user/workspace setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
+                                "type": "string"
+                            },
                             "executable": {
                                 "description": "Path of executable",
                                 "type": "string"
@@ -752,6 +757,11 @@
                             "armToolchainPath": {
                                 "default": null,
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
+                                "type": "string"
+                            },
+                            "serverpath": {
+                                "default": null,
+                                "description": "This setting can be used to override the gdb-server path user/workspace setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
                                 "type": "string"
                             },
                             "executable": {

--- a/package.json
+++ b/package.json
@@ -253,14 +253,9 @@
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
                                 "type": "string"
                             },
-                            "toolchainPrefix": {
-                                "default": null,
-                                "description": "This setting can be used to override the toolchainPrefix user setting for a particular launch configuration.",
-                                "type": "string"
-                            },
                             "serverpath": {
                                 "default": null,
-                                "description": "This setting can be used to override the gdb-server path user/workspace setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
+                                "description": "This setting can be used to override the gdb-server path user/workspac setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
                                 "type": "string"
                             },
                             "executable": {
@@ -764,14 +759,9 @@
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
                                 "type": "string"
                             },
-                            "toolchainPrefix": {
-                                "default": null,
-                                "description": "This setting can be used to override the toolchainPrefix user setting for a particular launch configuration.",
-                                "type": "string"
-                            },
                             "serverpath": {
                                 "default": null,
-                                "description": "This setting can be used to override the gdb-server path user/workspace setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
+                                "description": "This setting can be used to override the gdb-server path user/workspac setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
                                 "type": "string"
                             },
                             "executable": {

--- a/package.json
+++ b/package.json
@@ -253,6 +253,11 @@
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
                                 "type": "string"
                             },
+                            "serverpath": {
+                                "default": null,
+                                "description": "This setting can be used to override the gdb-server path user/workspac setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
+                                "type": "string"
+                            },
                             "executable": {
                                 "description": "Path of executable",
                                 "type": "string"
@@ -752,6 +757,11 @@
                             "armToolchainPath": {
                                 "default": null,
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
+                                "type": "string"
+                            },
+                            "serverpath": {
+                                "default": null,
+                                "description": "This setting can be used to override the gdb-server path user/workspac setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
                                 "type": "string"
                             },
                             "executable": {

--- a/package.json
+++ b/package.json
@@ -253,11 +253,6 @@
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
                                 "type": "string"
                             },
-                            "serverpath": {
-                                "default": null,
-                                "description": "This setting can be used to override the gdb-server path user/workspac setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
-                                "type": "string"
-                            },
                             "executable": {
                                 "description": "Path of executable",
                                 "type": "string"
@@ -757,11 +752,6 @@
                             "armToolchainPath": {
                                 "default": null,
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
-                                "type": "string"
-                            },
-                            "serverpath": {
-                                "default": null,
-                                "description": "This setting can be used to override the gdb-server path user/workspac setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
                                 "type": "string"
                             },
                             "executable": {

--- a/package.json
+++ b/package.json
@@ -253,9 +253,14 @@
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
                                 "type": "string"
                             },
+                            "toolchainPrefix": {
+                                "default": null,
+                                "description": "This setting can be used to override the toolchainPrefix user setting for a particular launch configuration.",
+                                "type": "string"
+                            },
                             "serverpath": {
                                 "default": null,
-                                "description": "This setting can be used to override the gdb-server path user/workspac setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
+                                "description": "This setting can be used to override the gdb-server path user/workspace setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
                                 "type": "string"
                             },
                             "executable": {
@@ -759,9 +764,14 @@
                                 "description": "This setting can be used to override the armToolchainPath user setting for a particular launch configuration. This should be the path where arm-none-eabi-gdb and arm-none-eabi-objdump are located.",
                                 "type": "string"
                             },
+                            "toolchainPrefix": {
+                                "default": null,
+                                "description": "This setting can be used to override the toolchainPrefix user setting for a particular launch configuration.",
+                                "type": "string"
+                            },
                             "serverpath": {
                                 "default": null,
-                                "description": "This setting can be used to override the gdb-server path user/workspac setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
+                                "description": "This setting can be used to override the gdb-server path user/workspace setting for a particular launch configuration. It is the full pathname to the executable or name of executable if it is in your PATH",
                                 "type": "string"
                             },
                             "executable": {

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -96,7 +96,9 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
         if (!config.toolchainPath) {
             config.toolchainPath = configuration.armToolchainPath;
         }
-        config.toolchainPrefix = configuration.armToolchainPrefix || 'arm-none-eabi';
+        if (!config.toolchainPrefix) {
+            config.toolchainPrefix = configuration.armToolchainPrefix || 'arm-none-eabi';
+        }
         
         config.extensionPath = this.context.extensionPath;
         if (os.platform() === 'win32') {

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as os from 'os';
 
-const OPENOCD_VALID_RTOS: string[] = ['eCos', 'ThreadX', 'FreeRTOS', 'ChibiOS', 'embKernel', 'mqx', 'uCOS-III'];
+const OPENOCD_VALID_RTOS: string[] = ['eCos', 'ThreadX', 'FreeRTOS', 'ChibiOS', 'embKernel', 'mqx', 'uCOS-III', 'auto'];
 const JLINK_VALID_RTOS: string[] = ['FreeRTOS', 'embOS'];
 
 export class CortexDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
@@ -13,6 +13,13 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
         config: vscode.DebugConfiguration,
         token?: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.DebugConfiguration> {
+        // Flatten the platform specific stuff as it is not done by VSCode at this point.
+        switch (os.platform()) {
+            case 'darwin': Object.assign(config, config.osx); delete config.osx; break;
+            case 'win32': Object.assign(config, config.windows); delete config.windows; break;
+            case 'linux': Object.assign(config, config.linux); delete config.linux; break;
+            default: console.log(`Unknown platform ${os.platform()}`);
+        }
         if (config.debugger_args && !config.debuggerArgs) {
             config.debuggerArgs = config.debugger_args;
         }

--- a/src/frontend/memreadutils.ts
+++ b/src/frontend/memreadutils.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { AddrRange, AddressRangesInUse } from './addrranges';
 
 /** Has utility functions to read memory in chunks into a storage space */
-export module MemReadUtils {
+export class MemReadUtils {
     /**
      * Make one or more memory reads and update values. For the caller, it should look like a single
      * memory read but, if one read fails, all reads are considered as failed.
@@ -11,7 +11,7 @@ export module MemReadUtils {
      * @param specs The chunks of memory to read and and update. Addresses should be >= `startAddr`, Can have gaps, overlaps, etc.
      * @param storeTo This is where read-results go. The first element represents item at `startAddr`
      */
-    export function readMemoryChunks(startAddr: number, specs: AddrRange[], storeTo: number[]): Promise<boolean> {
+    public static readMemoryChunks(startAddr: number, specs: AddrRange[], storeTo: number[]): Promise<boolean> {
         const promises = specs.map((r) => {
             return new Promise((resolve, reject) => {
                 vscode.debug.activeDebugSession.customRequest('read-memory', { address: r.base, length: r.length }).then((data) => {
@@ -36,7 +36,7 @@ export module MemReadUtils {
         });
     }
 
-    export function readMemory(startAddr: number, length: number, storeTo: number[]): Promise<boolean> {
+    public static readMemory(startAddr: number, length: number, storeTo: number[]): Promise<boolean> {
         const maxChunk = (4 * 1024);
         const ranges = AddressRangesInUse.splitIntoChunks([new AddrRange(startAddr, length)], maxChunk);
         return MemReadUtils.readMemoryChunks(startAddr, ranges, storeTo);

--- a/src/tcpportscanner.ts
+++ b/src/tcpportscanner.ts
@@ -439,11 +439,12 @@ export class TcpPortScanner {
         if (TcpPortScanner.localHostAliases.length === 0) {
             // On Unixes, the first two are treated like true aliases but on Windows
             // you have distint servers on all of them. So, try everything.
-            TcpPortScanner.localHostAliases = ['0.0.0.0', '127.0.0.1', '::1', ''];
+            TcpPortScanner.localHostAliases = ['0.0.0.0', '127.0.0.1', ''];
             const ifaces = os.networkInterfaces();
             Object.keys(ifaces).forEach((ifname) => {
                 ifaces[ifname].forEach((iface) => {
-                    if ('ipv4' === iface.family.toLowerCase()) {
+                    // Skip external interfaces (VPN tunnels, actual IP, etc). Only want loopbacks
+                    if (iface.internal && ('ipv4' === iface.family.toLowerCase())) {
                         if (TcpPortScanner.localHostAliases.indexOf(iface.address) === -1) {
                             TcpPortScanner.localHostAliases.push(iface.address);
                         }

--- a/test/tcpportscanner.test.ts
+++ b/test/tcpportscanner.test.ts
@@ -74,6 +74,14 @@ suite('TcpPortScanner Tests', () => {
                 assert.fail('unexpected timeout ' + err);
             });
 
+            timeit();
+            await TcpPortScanner.waitForPortOpenOSUtil(port, 50, 1000, false, doLog).then(() => {
+                if (doLog) { console.log(`1.1 Success server port ${port} is ready ${timeit()}`); }
+            }, (err) => {
+                if (doLog) { console.log(`1.1 Timeout: Failed waiting on port ${port} to open ${timeit()}`, err); }
+                assert.fail('unexpected timeout ' + err);
+            });
+
             // Lets see if consecutive ports request works while server is still running. It should
             // skip the port we are already using
             args.consecutive = true;


### PR DESCRIPTION
Fix for Issue #155 Should also fix Issue #177

Only affects people using VPN tunnels. Sometimes VPNs open a special IP address for a tunnel and creating a server on that port fails and we discard the entire port because of one IP address alias failing.

We now only look for IPv4 and internal (loopback) IP aliases to be free. Greater chances of success and fewer chances of errors due to VPN weirdness.

I also added another function waitForPortOpenOSUtil(). This works based on what the OS tells us what the port is doing rather than create a server or a client. Totally unobtrusive but slow. I haven't pushed the change to server.ts to use this yet but it is in my code base.
