### PR TITLE
Fix build on case sensitive file systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist
 out
 node_modules
 *.vsix

--- a/src/grapher/main.ts
+++ b/src/grapher/main.ts
@@ -1,6 +1,6 @@
-import { TimeseriesGraph } from './TimeSeriesGraph';
-import { XYGraph } from './XYGraph';
-import { ProgramStatsGraph } from './ProgramStatsGraph';
+import { TimeseriesGraph } from './timeseriesgraph';
+import { XYGraph } from './xygraph';
+import { ProgramStatsGraph } from './programstatsgraph';
 import { Graph, GrapherConfigurationMessage, TimeseriesGraphConfiguration, XYGraphConfiguration, GrapherMessage, GrapherDataMessage, GrapherStatusMessage, GrapherProgramCounterMessage } from './types';
 import { GraphDataSource } from './datasource';
 


### PR DESCRIPTION
When testing #175 I ran into issues building because I'm running on EXT4 which is a case sensitive file system. This caused a few imports to fail because of a difference between the filenames on disk and the filenames referenced in the source.

With these changes I'm able to build cleanly on a case sensitive file system.