### PR TITLE
Separate swo config. from launch/attach/restart commands

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -237,10 +237,8 @@ export class MI2 extends EventEmitter implements IBackend {
     }
 
     public detach() {
-        const proc = this.process;
-        const to = setTimeout(() => { this.tryKill(); }, 1000);
-        this.process.on('exit', (code) => { clearTimeout(to); });
-        this.sendRaw('-target-detach');
+        this.sendCommand('target-detach');
+        this.stop();
     }
 
     public interrupt(threadId: number): Thenable<boolean> {

--- a/src/bmp.ts
+++ b/src/bmp.ts
@@ -64,12 +64,6 @@ export class BMPServerController extends EventEmitter implements GDBServerContro
             'interpreter-exec console "SoftwareReset"',
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled) {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-
         return commands;
     }
 
@@ -77,12 +71,6 @@ export class BMPServerController extends EventEmitter implements GDBServerContro
         const commands = [
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled) {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-
         return commands;
     }
 
@@ -90,12 +78,15 @@ export class BMPServerController extends EventEmitter implements GDBServerContro
         const commands: string[] = [
             'interpreter-exec console "SoftwareReset"'
         ];
+        return commands;
+    }
 
+    public swoCommands(): string[]{
+        const commands = [];
         if (this.args.swoConfig.enabled) {
             const swocommands = this.SWOConfigurationCommands();
             commands.push(...swocommands);
         }
-
         return commands;
     }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -164,6 +164,7 @@ export interface GDBServerController extends EventEmitter {
     launchCommands(): string[];
     attachCommands(): string[];
     restartCommands(): string[];
+    swoCommands(): string[];
     serverExecutable(): string;
     serverArguments(): string[];
     initMatch(): RegExp;

--- a/src/external.ts
+++ b/src/external.ts
@@ -53,6 +53,10 @@ export class ExternalServerController extends EventEmitter implements GDBServerC
         return commands;
     }
 
+    public swoCommands(): string[] {
+        return [];
+    }
+
     public restartCommands(): string[] {
         const commands: string[] = [
             'interpreter-exec console "monitor reset halt"'

--- a/src/jlink.ts
+++ b/src/jlink.ts
@@ -45,12 +45,6 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
             'interpreter-exec console "monitor reset"',
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled) {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-
         return commands;
     }
 
@@ -59,12 +53,6 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
             'interpreter-exec console "monitor halt"',
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled) {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-        
         return commands;
     }
 
@@ -73,12 +61,15 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
             'interpreter-exec console "monitor halt"',
             'interpreter-exec console "monitor reset"'
         ];
+        return commands;
+    }
 
+    public swoCommands(): string[] {
+        const commands = [];
         if (this.args.swoConfig.enabled) {
             const swocommands = this.SWOConfigurationCommands();
             commands.push(...swocommands);
         }
-
         return commands;
     }
 

--- a/src/openocd.ts
+++ b/src/openocd.ts
@@ -45,12 +45,6 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
             'interpreter-exec console "monitor reset halt"',
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled) {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-
         return commands;
     }
 
@@ -59,12 +53,6 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
             'interpreter-exec console "monitor halt"',
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled) {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-
         return commands;
     }
 
@@ -72,12 +60,15 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
         const commands: string[] = [
             'interpreter-exec console "monitor reset halt"'
         ];
+        return commands;
+    }
 
+    public swoCommands(): string[] {
+        const commands = [];
         if (this.args.swoConfig.enabled) {
             const swocommands = this.SWOConfigurationCommands();
             commands.push(...swocommands);
         }
-
         return commands;
     }
 

--- a/src/pemicro.ts
+++ b/src/pemicro.ts
@@ -64,6 +64,10 @@ export class PEServerController extends EventEmitter implements GDBServerControl
         return commands;
     }
 
+    public swoCommands(): string[] {
+        return [];
+    }
+
     public serverExecutable() {
         
         console.log('Getting Exec');

--- a/src/pyocd.ts
+++ b/src/pyocd.ts
@@ -41,12 +41,6 @@ export class PyOCDServerController extends EventEmitter implements GDBServerCont
             'interpreter-exec console "monitor reset halt"',
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled && this.args.swoConfig.source !== 'probe') {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-
         return commands;
     }
 
@@ -57,12 +51,6 @@ export class PyOCDServerController extends EventEmitter implements GDBServerCont
             'interpreter-exec console "monitor halt"',
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled && this.args.swoConfig.source !== 'probe') {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-
         return commands;
     }
 
@@ -70,12 +58,15 @@ export class PyOCDServerController extends EventEmitter implements GDBServerCont
         const commands: string[] = [
             'interpreter-exec console "monitor reset"'
         ];
+        return commands;
+    }
 
+    public swoCommands(): string[] {
+        const commands = [];
         if (this.args.swoConfig.enabled && this.args.swoConfig.source !== 'probe') {
             const swocommands = this.SWOConfigurationCommands();
             commands.push(...swocommands);
         }
-
         return commands;
     }
 

--- a/src/qemu.ts
+++ b/src/qemu.ts
@@ -62,6 +62,10 @@ export class QEMUServerController extends EventEmitter implements GDBServerContr
         return commands;
     }
 
+    public swoCommands(): string[] {
+        return [];
+    }
+
     public serverExecutable() {
         if (this.args.serverpath) { return this.args.serverpath; }
         else {

--- a/src/stutil.ts
+++ b/src/stutil.ts
@@ -42,12 +42,6 @@ export class STUtilServerController extends EventEmitter implements GDBServerCon
             'interpreter-exec console "monitor reset"',
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled && this.args.swoConfig.source !== 'probe') {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-
         return commands;
     }
 
@@ -56,12 +50,6 @@ export class STUtilServerController extends EventEmitter implements GDBServerCon
             'interpreter-exec console "monitor halt"',
             'enable-pretty-printing'
         ];
-
-        if (this.args.swoConfig.enabled && this.args.swoConfig.source !== 'probe') {
-            const swocommands = this.SWOConfigurationCommands();
-            commands.push(...swocommands);
-        }
-
         return commands;
     }
 
@@ -70,12 +58,15 @@ export class STUtilServerController extends EventEmitter implements GDBServerCon
             'interpreter-exec console "monitor halt"',
             'interpreter-exec console "monitor reset"'
         ];
+        return commands;
+    }
 
+    public swoCommands(): string[] {
+        const commands = [];
         if (this.args.swoConfig.enabled && this.args.swoConfig.source !== 'probe') {
             const swocommands = this.SWOConfigurationCommands();
             commands.push(...swocommands);
         }
-
         return commands;
     }
 


### PR DESCRIPTION
This PR will address #180 and issues related to attach/detach

- attach/detach related changes (mi2.ts && gdb.ts). If it is an attach session, we never set a flag to remember that although we test for it. For a detach to succeed, we have to interrupt first if not in a stopped state or else detach will fail. Send a normal detach request and then ask gdb to exit. Give gdb to detach/exit before killing server, cleanup, lock files, etc. The `disconnectRequest` is a bit more graceful now.

- Separate swo configuration commands from launch/attach/restart commands. Also, do the swo configuration **after postXXXcommands** since swo may not succeed until the launch is completely done.

As an aside, should we remove any breakpoints before a detach? I don't have a good test for it but I have a feeling neither gdb or the gdb-server removes the breakpoints. A safe way for users to detach is to pause, remove all breakpoints, continue and then request a detach. A better way to shutdown the server could be `monitor shutdown` for openocd, but such a command is not universal. Other gdb-servers use `monitor exit`

Note: I verified swo related changes by verifying the commands are being generated properly. I don't have a good SWO setup to fully verify.
