### PR TITLE
Thread fixes mainly plus some minor misc. changes and enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cortex-debug",
-    "version": "0.3.0",
+    "version": "0.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2289,7 +2289,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2310,12 +2311,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2330,17 +2333,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2457,7 +2463,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2469,6 +2476,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2483,6 +2491,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2490,12 +2499,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2514,6 +2525,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2594,7 +2606,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2606,6 +2619,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2691,7 +2705,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2727,6 +2742,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2746,6 +2762,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2789,12 +2806,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
                     "description": "Path to the GCC Arm Toolchain (standard prefix is \"arm-none-eabi\" - can be set through the armToolchainPrefix setting) to use. If not set the tools must be on the system path. Do not include the executable file name in this path."
                 },
                 "cortex-debug.armToolchainPrefix": {
-                    "type": ["string", "null"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "default": "arm-none-eabi",
                     "description": "The prefix to use for the arm toolchain - the standard release from arm uses \"arm-none-eabi\" but alternative toolchains may use a different prefix. Currently the gdb and objdump tools are needed."
                 },
@@ -214,6 +217,18 @@
                                 "type": "array",
                                 "items": "string",
                                 "description": "You can use this to property to override the commands that are normally executed as part of restarting the target. In most cases it is preferable to use preRestartCommands and postRestartCommands to customize the GDB restart sequence."
+                            },
+                            "postStartSessionCommands": {
+                                "default": [],
+                                "type": "array",
+                                "items": "string",
+                                "description": "Additional GDB Commands to be executed at the end of the start sequence, after a debug session has already started and runToMain is false."
+                            },
+                            "postRestartSessionCommands": {
+                                "default": [],
+                                "type": "array",
+                                "items": "string",
+                                "description": "Additional GDB Commands to be executed at the end of the re-start sequence, after a debug session has already started."
                             },
                             "overrideGDBServerStartedRegex": {
                                 "description": "You can supply a regular expression (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) in the configuration property to override the output from the GDB server that is looked for to determine if the GDB server has started. Under most circumstances this will not be necessary - but could be needed as a result of a change in the output of a GDB server making it incompatible with cortex-debug. This property has no effect for bmp or external GDB server types.",
@@ -725,6 +740,18 @@
                                 "type": "array",
                                 "items": "string",
                                 "description": "You can use this to property to override the commands that are normally executed as part of restarting the target. In most cases it is preferable to use preRestartCommands and postRestartCommands to customize the GDB restart sequence."
+                            },
+                            "postStartSessionCommands": {
+                                "default": [],
+                                "type": "array",
+                                "items": "string",
+                                "description": "Additional GDB Commands to be executed at the end of the start sequence, after a debug session has already started and runToMain is false."
+                            },
+                            "postRestartSessionCommands": {
+                                "default": [],
+                                "type": "array",
+                                "items": "string",
+                                "description": "Additional GDB Commands to be executed at the end of the re-start sequence, after a debug session has already started."
                             },
                             "overrideGDBServerStartedRegex": {
                                 "description": "You can supply a regular expression (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) in the configuration property to override the output from the GDB server that is looked for to determine if the GDB server has started. Under most circumstances this will not be necessary - but could be needed as a result of a change in the output of a GDB server making it incompatible with cortex-debug. This property has no effect for bmp or external GDB server types.",
@@ -1438,5 +1465,5 @@
         "compile": "webpack --mode development",
         "test-compile": "tsc -p ./"
     },
-    "version": "0.3.0"
+    "version": "0.3.2"
 }

--- a/package.json
+++ b/package.json
@@ -627,6 +627,22 @@
                                     "jtag"
                                 ]
                             },
+                            "openOCDLaunchCommands": {
+                                "default": [],
+                                "description": "OpenOCD commands after config. files are loaded (-c options)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "openOCDPreConfigLaunchCommands": {
+                                "default": [],
+                                "description": "OpenOCD commands before config. files are loaded (-c options)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
                             "configFiles": {
                                 "description": "OpenOCD/pegdbserver configuration file(s) to load",
                                 "items": {
@@ -1155,6 +1171,22 @@
                                 "default": null,
                                 "description": "J-Link script file - optional input file for customizing J-Link actions.",
                                 "type": "string"
+                            },
+                            "openOCDLaunchCommands": {
+                                "default": [],
+                                "description": "OpenOCD commands after config. files are loaded (-c options)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "openOCDPreConfigLaunchCommands": {
+                                "default": [],
+                                "description": "OpenOCD commands before config. files are loaded (-c options)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             },
                             "configFiles": {
                                 "description": "OpenOCD configuration file(s) to load",

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -30,7 +30,7 @@ export interface IBackend {
     connect(cwd: string, executable: string, target: string[]): Thenable<any>;
     stop();
     detach();
-    interrupt(threadId: number): Thenable<boolean>;
+    interrupt(arg: string): Thenable<boolean>;
     continue(threadId: number): Thenable<boolean>;
     next(threadId: number, instruction: boolean): Thenable<boolean>;
     step(threadId: number, instruction: boolean): Thenable<boolean>;
@@ -39,7 +39,7 @@ export interface IBackend {
     removeBreakpoints(breakpoints: number[]): Promise<boolean>;
     getStack(threadId: number, startLevel: number, maxLevels: number): Thenable<Stack[]>;
     getStackVariables(thread: number, frame: number): Thenable<Variable[]>;
-    evalExpression(name: string): Thenable<any>;
+    evalExpression(name: string, threadId: number, frameId: number): Thenable<any>;
     isReady(): boolean;
     changeVariable(name: string, rawValue: string): Thenable<any>;
     examineMemory(from: number, to: number): Thenable<any>;

--- a/src/backend/mi_parse.ts
+++ b/src/backend/mi_parse.ts
@@ -247,6 +247,7 @@ export function parseMI(output: string): MINode {
         const canBeValueList = output[0] === '[';
         output = output.substr(1);
         if (output[0] === '}' || output[0] === ']') {
+            output = output.substr(1);
             return [];
         }
         if (canBeValueList) {

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -33,7 +33,8 @@ export class GDBServer extends EventEmitter {
 
                 if ((typeof this.port === 'number') && (this.port > 0)) {
                     // We monitor for port getting into Listening mode. This is a backup for initMatch
-                    TcpPortScanner.waitForPortOpenOSUtil(this.port, 250, GDBServer.SERVER_TIMEOUT - 1000, true, false)
+                    // TcpPortScanner.waitForPortOpenOSUtil(this.port, 250, GDBServer.SERVER_TIMEOUT - 1000, true, false)
+                    TcpPortScanner.waitForPortOpen(this.port, GDBServer.LOCALHOST, true, 50, GDBServer.SERVER_TIMEOUT - 1000)
                     .then(() => {
                         if (this.initResolve) {
                             this.initResolve(true);
@@ -42,8 +43,8 @@ export class GDBServer extends EventEmitter {
                         }
                     }).catch((e) => {
                         // We could reject here if it is truly a timeout and not something else, caller already has a timeout
-                        // ALso, this is not bullet proof if it fails, we don't know why because of differences in OSes, upgrades, etc.
-                        // But, when it works, we know for sure it worked.
+                        // ALso, waitForPortOpenOSUtil is not bullet proof if it fails, we don't know why because of differences
+                        // in OSes, upgrades, etc. But, when it works, we know for sure it worked.
                     });
                 }
 

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -42,6 +42,8 @@ export class GDBServer extends EventEmitter {
                         }
                     }).catch((e) => {
                         // We could reject here if it is truly a timeout and not something else, caller already has a timeout
+                        // ALso, this is not bullet proof if it fails, we don't know why because of differences in OSes, upgrades, etc.
+                        // But, when it works, we know for sure it worked.
                     });
                 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -124,6 +124,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     configFiles: string[];
     searchDir: string[];
     openOCDLaunchCommands: string[];
+    openOCDPreConfigLaunchCommands: string[];
 
     // PyOCD Specific
     boardId: string;

--- a/src/common.ts
+++ b/src/common.ts
@@ -100,6 +100,8 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     preRestartCommands: string[];
     postRestartCommands: string[];
     overrideRestartCommands: string[];
+    postStartSessionCommands: string[];
+    postRestartSessionCommands: string[];
     overrideGDBServerStartedRegex: string;
     svdFile: string;
     swoConfig: SWOConfiguration;

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -28,6 +28,7 @@ interface SVDInfo {
 
 export class CortexDebugExtension {
     private adapterOutputChannel: vscode.OutputChannel = null;
+    private clearAdapterOutputChannel = false;
     private swo: SWOCore = null;
     private swosource: SWOSource = null;
 
@@ -370,6 +371,7 @@ export class CortexDebugExtension {
             this.swosource.dispose();
             this.swosource = null;
         }
+        this.clearAdapterOutputChannel = true;
     }
 
     private receivedCustomEvent(e: vscode.DebugSessionCustomEvent) {
@@ -441,7 +443,11 @@ export class CortexDebugExtension {
     private receivedAdapterOutput(e) {
         if (!this.adapterOutputChannel) {
             this.adapterOutputChannel = vscode.window.createOutputChannel('Adapter Output');
+            this.adapterOutputChannel.show();
+        } else if (this.clearAdapterOutputChannel) {
+            this.adapterOutputChannel.clear();
         }
+        this.clearAdapterOutputChannel = false;
 
         let output = e.body.content;
         if (!output.endsWith('\n')) { output += '\n'; }

--- a/src/frontend/svd.ts
+++ b/src/frontend/svd.ts
@@ -26,7 +26,7 @@ export class SVDParser {
         return new Promise((resolve, reject) => {
             fs.readFile(path, 'utf8', (err, data) => {
                 if (err) {
-                    reject(path + ': ' + err.message);
+                    reject(err);
                     return;
                 }
 
@@ -83,7 +83,9 @@ export class SVDParser {
                         }
                     });
 
-                    peripherials.forEach((p) => { p.markAddresses(); });
+                    for (const p of peripherials) {
+                        p.markAddresses();
+                    }
                     
                     resolve(peripherials);
                 });
@@ -343,11 +345,13 @@ export class SVDParser {
         
         const peripheral = new PeripheralNode(options);
 
-        if (p.registers[0].register) {
-            SVDParser.parseRegisters(p.registers[0].register, peripheral);
-        }
-        if (p.registers[0].cluster) {
-            SVDParser.parseClusters(p.registers[0].cluster, peripheral);
+        if (p.registers) {
+            if (p.registers[0].register) {
+                SVDParser.parseRegisters(p.registers[0].register, peripheral);
+            }
+            if (p.registers[0].cluster) {
+                SVDParser.parseClusters(p.registers[0].cluster, peripheral);
+            }
         }
 
         return peripheral;

--- a/src/frontend/svd.ts
+++ b/src/frontend/svd.ts
@@ -26,7 +26,7 @@ export class SVDParser {
         return new Promise((resolve, reject) => {
             fs.readFile(path, 'utf8', (err, data) => {
                 if (err) {
-                    reject(err);
+                    reject(path + ': ' + err.message);
                     return;
                 }
 

--- a/src/frontend/views/peripheral.ts
+++ b/src/frontend/views/peripheral.ts
@@ -17,6 +17,7 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
     
     private peripherials: PeripheralNode[] = [];
     private loaded: boolean = false;
+    private svdFileName: string | null;
     
     constructor() {
 
@@ -37,6 +38,7 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
             SVDFile = fullpath;
         }
 
+        this.svdFileName = SVDFile;
         return SVDParser.parseSVD(SVDFile).then((peripherals) => {
             this.peripherials = peripherals;
             this.loaded = true;
@@ -70,7 +72,7 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
             }
         }
         else if (!this.loaded) {
-            return [new MessageNode('No SVD File Loaded', null)];
+            return [new MessageNode('No SVD File Loaded: ' + this.svdFileName || 'None', null)];
         }
         else {
             return [];
@@ -112,7 +114,11 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
                             this.peripherials = [];
                             this.loaded = false;
                             this._onDidChangeTreeData.fire();
-                            vscode.window.showErrorMessage(`Unable to parse SVD file: ${e.toString()}`);
+                            const msg = `Unable to parse SVD file: ${e.toString()}`;
+                            vscode.window.showErrorMessage(msg);
+                            if (vscode.debug.activeDebugConsole) {
+                                vscode.debug.activeDebugConsole.appendLine(msg);
+                            }
                             resolve();
                             reporting.sendEvent('Peripheral View', 'Error', e.toString());
                         }

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -28,7 +28,6 @@ import { ExternalServerController } from './external';
 import { SymbolTable } from './backend/symbols';
 import { SymbolInformation, SymbolScope, SymbolType } from './symbols';
 import { TcpPortScanner } from './tcpportscanner';
-import { threadId } from 'worker_threads';
 
 const SERVER_TYPE_MAP = {
     jlink: JLinkServerController,

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -78,6 +78,8 @@ class CustomContinuedEvent extends Event implements DebugProtocol.Event {
     }
 }
 
+const traceThreads = false;
+
 export class GDBDebugSession extends DebugSession {
     private server: GDBServer;
     private args: ConfigurationArguments;
@@ -89,6 +91,7 @@ export class GDBDebugSession extends DebugSession {
     protected variableHandlesReverse: { [id: string]: number } = {};
     protected quit: boolean;
     protected attached: boolean;
+    protected detaching: boolean;
     protected trimCWD: string;
     protected switchCWD: string;
     protected started: boolean;
@@ -99,6 +102,7 @@ export class GDBDebugSession extends DebugSession {
     protected forceDisassembly: boolean = false;
     protected activeEditorPath: string = null;
     protected currentThreadId: number = 0;
+    protected activeThreadIds = new Set<number>();
     
     private stopped: boolean = false;
     private stoppedReason: string = '';
@@ -127,6 +131,7 @@ export class GDBDebugSession extends DebugSession {
         this.miDebugger.on('thread-created', this.handleThreadCreated.bind(this));
         this.miDebugger.on('thread-exited', this.handleThreadExited.bind(this));
         this.miDebugger.on('thread-selected', this.handleThreadSelected.bind(this));
+        this.miDebugger.on('thread-group-exited', this.handleThreadGroupExited.bind(this));
         this.sendEvent(new InitializedEvent());
     }
 
@@ -203,6 +208,7 @@ export class GDBDebugSession extends DebugSession {
         this.crashed = false;
         this.debugReady = false;
         this.stopped = false;
+        this.activeThreadIds.clear();
 
         const portFinderOpts = { min: 50000, max: 52000, retrieve: this.serverController.portsNeeded.length };
         TcpPortScanner.findFreePorts(portFinderOpts, GDBServer.LOCALHOST).then((ports) => {
@@ -248,9 +254,11 @@ export class GDBDebugSession extends DebugSession {
                 }
             }
 
-            if (this.args.showDevDebugOutput && executable) {
-                this.handleMsg('log', `Please check OUTPUT tab (Adapter Output) for log of ${executable}` + '\n');
-                const dbgMsg = `Launching server: "${executable}" ` + args.map((s) => `"${s}"`).join(' ') + '\n';
+            if (executable) {
+                this.handleMsg('log', `Please check OUTPUT tab (Adapter Output) for output from ${executable}` + '\n');
+                const dbgMsg = `Launching server: "${executable}" ` + args.map((s) => {
+                    return '"' + s.replace(/"/g, '\\"') + '"';
+                }).join(' ') + '\n';
                 this.handleMsg('log', dbgMsg);
             }
 
@@ -259,7 +267,7 @@ export class GDBDebugSession extends DebugSession {
                 initMatch = new RegExp(this.args.overrideGDBServerStartedRegex, 'i');
             }
 
-            this.server = new GDBServer(executable, args, initMatch, this.ports['gdbPort']);
+            this.server = new GDBServer(this.args.cwd, executable, args, initMatch, this.ports['gdbPort']);
             this.server.on('output', this.handleAdapterOutput.bind(this));
             this.server.on('quit', () => {
                 if (this.started) {
@@ -330,6 +338,14 @@ export class GDBDebugSession extends DebugSession {
                     this.debugReady = true;
                     this.attached = attach;
                 });
+
+                if (true) {
+                    const dbgMsg = `Launching GDB: "${gdbExePath}" ` + gdbargs.map((s) => {
+                        return '"' + s.replace(/"/g, '\\"') + '"';
+                    }).join(' ') + '\n';
+                    this.handleMsg('log', dbgMsg);
+                }
+
                 this.miDebugger.connect(this.args.cwd, this.args.executable, commands).then(() => {
                     this.started = true;
                     this.serverController.debuggerLaunchCompleted();
@@ -357,6 +373,9 @@ export class GDBDebugSession extends DebugSession {
                     }
                     else {
                         launchComplete();
+                        this.onConfigDone.once('done', () => {
+                            this.runPostStartSessionCommands(false);
+                        });
                     }
                 }, (err) => {
                     this.sendErrorResponse(response, 103, `Failed to launch GDB: ${err.toString()}`);
@@ -380,6 +399,27 @@ export class GDBDebugSession extends DebugSession {
             this.sendEvent(new TelemetryEvent('Error', 'Launching Server', `Failed to find open ports: ${err.toString()}`));
             this.sendErrorResponse(response, 103, `Failed to find open ports: ${err.toString()}`);
         });
+    }
+
+    // Runs a set of commands after a quiet time and is no other gdb transactions are happening
+    protected runPostStartSessionCommands(isRestart: boolean, interval: number = 10): void {
+        let commands = isRestart ? this.args.postRestartSessionCommands : this.args.postStartSessionCommands;
+        if (commands && (commands.length > 0)) {
+            let curToken = this.miDebugger.getCurrentToken();
+            commands = commands.map(COMMAND_MAP);
+            // We want to let things quiet down before we run the next set of commands. Note that while
+            // we are running this command sequence, some results can cause other gdb commands to be generated if
+            // running state changes. Can't help it for now
+            const to = setInterval(() => {
+                const nxtToken = this.miDebugger.getCurrentToken();
+                if (curToken === nxtToken) {
+                    clearInterval(to);
+                    this.miDebugger.postStart(commands);
+                } else {
+                    curToken = nxtToken;
+                }
+            }, interval);
+        }
     }
 
     protected customRequest(command: string, response: DebugProtocol.Response, args: any): void {
@@ -636,31 +676,40 @@ export class GDBDebugSession extends DebugSession {
     }
 
     protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void {
-        if (this.miDebugger) {
+        const doDisconnectProcessing = () => {
             if (this.attached) {
                 this.attached = false;
-                if (!this.stopped) {
-                    this.miDebugger.sendCommand('exec-interrupt');
-                }
+                this.detaching = true;
                 this.miDebugger.detach();
             } else {
                 this.miDebugger.stop();
             }
-        }
-        if (this.commandServer) {
-            this.commandServer.close();
-            this.commandServer = undefined;
-        }
+            if (this.commandServer) {
+                this.commandServer.close();
+                this.commandServer = undefined;
+            }
+            setTimeout(() => {      // Give gdb a chance to  disconnect and exit normally
+                try {this.server.exit(); }
+                catch (e) {}
+            }, 100);
+        };
 
-        setTimeout(() => {      // Give gdb a chance to  disconnect and exit normally
-            try {this.server.exit(); }
-            catch (e) {}
-        }, 100);
+        if (this.miDebugger) {
+            if (this.attached && !this.stopped) {
+                this.miDebugger.once('generic-stopped', doDisconnectProcessing);
+                this.miDebugger.sendCommand('exec-interrupt');
+            } else {
+                doDisconnectProcessing();
+            }
+        }
         this.sendResponse(response);
     }
 
+    protected restarting = false;
     protected restartRequest(response: DebugProtocol.RestartResponse, args: DebugProtocol.RestartArguments): void {
-        const restartProcessing = () => {
+        const restartProcessing = async () => {
+            this.currentThreadId = 0;
+            this.activeThreadIds.clear();
             const commands = [];
 
             commands.push(...this.args.preRestartCommands.map(COMMAND_MAP));
@@ -673,15 +722,23 @@ export class GDBDebugSession extends DebugSession {
             this.miDebugger.restart(commands).then((done) => {
                 this.sendResponse(response);
                 setTimeout(() => {
-                    this.stopped = true;
+                    this.restarting = false;
+                    this.stopped = true;        // This should aleady be true??
                     this.stoppedReason = 'restart';
                     this.sendEvent(new ContinuedEvent(this.currentThreadId, true));
                     this.sendEvent(new StoppedEvent('restart', this.currentThreadId, true));
+                    this.sendEvent(new CustomStoppedEvent('restart', this.currentThreadId));
+                    this.runPostStartSessionCommands(true, 50);
                 }, 50);
             }, (msg) => {
                 this.sendErrorResponse(response, 6, `Could not restart: ${msg}`);
             });
         };
+
+        // When the exec-interrupt happens, there will be resulting events and requests coming and we want
+        // try and suppress those and let things settle down. Or else, it may interrupt the restart sequence
+        // We want to keep our own state valid but not generate events that can produce further gdb chatter
+        this.restarting = true;
 
         if (this.stopped) {
             restartProcessing();
@@ -712,38 +769,99 @@ export class GDBDebugSession extends DebugSession {
         this.sendEvent(new CustomContinuedEvent(this.currentThreadId, true));
     }
 
+    protected findPausedThread(info: MINode) {
+        if (info.outOfBandRecord && info.outOfBandRecord[0] && info.outOfBandRecord[0].output) {
+            for (const item of info.outOfBandRecord[0].output) {
+                if (item[0] === 'thread-id') {
+                    this.currentThreadId = parseInt(item[1]);
+                    return;
+                }
+            }
+        }
+    }
+    
     protected handleBreakpoint(info: MINode) {
         this.stopped = true;
         this.stoppedReason = 'breakpoint';
-        this.sendEvent(new StoppedEvent('breakpoint', this.currentThreadId, true));
-        this.sendEvent(new CustomStoppedEvent('breakpoint', this.currentThreadId));
+        this.findPausedThread(info);
+        if (!this.restarting) {
+            this.sendEvent(new StoppedEvent('breakpoint', this.currentThreadId, true));
+            this.sendEvent(new CustomStoppedEvent('breakpoint', this.currentThreadId));
+        }
     }
 
     protected handleBreak(info: MINode) {
         this.stopped = true;
         this.stoppedReason = 'step';
-        this.sendEvent(new StoppedEvent('step', this.currentThreadId, true));
-        this.sendEvent(new CustomStoppedEvent('step', this.currentThreadId));
+        this.findPausedThread(info);
+        if (!this.restarting) {
+            this.sendEvent(new StoppedEvent('step', this.currentThreadId, true));
+            this.sendEvent(new CustomStoppedEvent('step', this.currentThreadId));
+        }
+    }
+
+    // Rename this to 'sendEvent' to monitor specific events this after debug finished
+    public sendEventUnused(event: DebugProtocol.Event): void {
+        super.sendEvent(event);
+        if (event instanceof StoppedEvent || event instanceof ContinuedEvent) {
+            this.handleMsg('stdout', 'Event: ' + JSON.stringify(event) + '\n');
+        }
     }
 
     protected handlePause(info: MINode) {
         this.stopped = true;
         this.stoppedReason = 'user request';
-        this.sendEvent(new StoppedEvent('user request', this.currentThreadId, true));
-        this.sendEvent(new CustomStoppedEvent('user request', this.currentThreadId));
+        this.findPausedThread(info);
+        if (!this.restarting) {
+            this.sendEvent(new StoppedEvent('user request', this.currentThreadId, true));
+            this.sendEvent(new CustomStoppedEvent('user request', this.currentThreadId));
+        }
     }
 
-    protected handleThreadCreated(info: { threadId: number, threadGroupId: number }) {
-        this.sendEvent(new ThreadEvent('started', info.threadId));
+    protected handleThreadCreated(info: { threadId: number, threadGroupId: string }) {
+        if (!this.activeThreadIds.has(info.threadId)) {
+            if (traceThreads) {
+                this.handleMsg('log', `**** Thread created ${info.threadId}\n`);
+            }
+            if (this.activeThreadIds.size === 0) {
+                this.currentThreadId = info.threadId;
+            }
+            this.activeThreadIds.add(info.threadId);
+            this.sendEvent(new ThreadEvent('started', info.threadId));
+        }
     }
 
-    protected handleThreadExited(info: { threadId: number, threadGroupId: number }) {
+    protected handleThreadExited(info: { threadId: number, threadGroupId: string }) {
+        if (traceThreads) {
+            this.handleMsg('log', `**** Thread exited ${info.threadId}\n`);
+        }
+        this.activeThreadIds.delete(info.threadId);
+        if (this.currentThreadId === info.threadId) {
+            this.currentThreadId = 0;
+        }
         this.sendEvent(new ThreadEvent('exited', info.threadId));
     }
 
     protected handleThreadSelected(info: { threadId: number }) {
+        if (traceThreads) {
+            this.handleMsg('log', `**** Thread selected ${info.threadId}\n`);
+        }
         this.currentThreadId = info.threadId;
         this.sendEvent(new ThreadEvent('selected', info.threadId));
+    }
+
+    protected handleThreadGroupExited(info: { threadGroupId: string }) {
+        if (traceThreads) {
+            this.handleMsg('log', `**** Thread group exited ${info.threadGroupId}\n`);
+        }
+        // When a thread group exits for whaever reason (especially for a re-start) cleanup
+        // and notify VSCode or it will be in a bad state. This can be distinct from a quitEvent
+        // A crash, hd/tcp disconnect in the gdb-server can also cause this event.
+        this.currentThreadId = 0;
+        for (const thId of this.activeThreadIds.values()) {
+            this.sendEvent(new ThreadEvent('exited', thId));
+        }
+        this.activeThreadIds.clear();
     }
 
     protected stopEvent(info: MINode) {
@@ -757,6 +875,9 @@ export class GDBDebugSession extends DebugSession {
     }
 
     protected quitEvent() {
+        if (traceThreads) {
+            this.handleMsg('log', '**** quit event\n');
+        }
         this.quit = true;
         this.sendEvent(new TerminatedEvent());
     }
@@ -767,22 +888,42 @@ export class GDBDebugSession extends DebugSession {
         this.quitEvent();
     }
 
+    // returns [threadId, frameId]
+    protected static decodeReference(varRef: number): number[] {
+        return [(varRef & 0xFF00) >>> 8, varRef & 0xFF];
+    }
+
+    protected static encodeReference(threadId: number, frameId: number): number {
+        return ((threadId << 8) | (frameId & 0xFF)) & 0xFFFF;
+    }
+
     protected async setVariableRequest(response: DebugProtocol.SetVariableResponse, args: DebugProtocol.SetVariableArguments): Promise<void> {
         try {
             let name = args.name;
-            if (args.variablesReference >= VAR_HANDLES_START) {
+            let threadId = -1;
+            let frameId = -1;
+            const varRef = args.variablesReference;
+            if (varRef >= VAR_HANDLES_START) {
                 const parent = this.variableHandles.get(args.variablesReference) as VariableObject;
                 name = `${parent.name}.${name}`;
+            } else if (varRef === GLOBAL_HANDLE_ID) {
+                name = 'global_var_' + name;
+            } else if (varRef >= STACK_HANDLES_START && varRef < STACK_HANDLES_FINISH) {
+                const tryName = this.createStackVarName(name, varRef);
+                if (this.variableHandlesReverse.hasOwnProperty(tryName)) {
+                    name = tryName;
+                }
+                [threadId, frameId] = GDBDebugSession.decodeReference(varRef);
             }
 
-            const res = await this.miDebugger.varAssign(name, args.value);
+            const res = await this.miDebugger.varAssign(name, args.value, threadId, frameId);
             response.body = {
                 value: res.result('value')
             };
             this.sendResponse(response);
         }
         catch (err) {
-            this.sendErrorResponse(response, 11, `Could not continue: ${err}`);
+            this.sendErrorResponse(response, 11, `Could not set variable: ${err}`);
         }
     }
 
@@ -922,22 +1063,44 @@ export class GDBDebugSession extends DebugSession {
     }
 
     protected async threadsRequest(response: DebugProtocol.ThreadsResponse): Promise<void> {
-        if (!this.stopped) {
+        if (!this.stopped || this.restarting) {
             response.body = { threads: [] };
             this.sendResponse(response);
+            return Promise.resolve();
         }
         try {
             const threadIdNode = await this.miDebugger.sendCommand('thread-list-ids');
             const threadIds: number[] = threadIdNode.result('thread-ids').map((ti) => parseInt(ti[1]));
             const currentThread = threadIdNode.result('current-thread-id');
 
+            if (!threadIds || (threadIds.length === 0)) {
+                // Yes, this does happen at the very beginning of an RTOS session
+                response.body = { threads: [] };
+                this.sendResponse(response);
+                return Promise.resolve();
+            }
+
+            for (const thId of threadIds) {
+                // Make sure VSCode knows about all the threads. GDB may still be in the process of notifying
+                // new threads while we already have a thread-list
+                this.handleThreadCreated({threadId: thId, threadGroupId: 'i1'});
+            }
+
             if (!currentThread) {
-                await this.miDebugger.sendCommand(`thread-select ${threadIds[0]}`);
-                this.currentThreadId = threadIds[0];
+                if (!this.activeThreadIds.has(this.currentThreadId)) {
+                    this.currentThreadId = threadIds[0];
+                    // Following doesn't actually work on most embedded gdb-servers. But we will at least
+                    // be in sync with gdb. Things may rectify themselves like they do with OpenOCD bit later
+                    await this.miDebugger.sendCommand(`thread-select ${this.currentThreadId}`);
+                }
             }
             else {
                 this.currentThreadId = parseInt(currentThread);
             }
+
+            /* We have to send this event or else VSCode may have the last/wrong/no thread selected
+             * even though we sent events when a pause/breakpoint happened */
+            this.sendEvent(new ThreadEvent('selected', this.currentThreadId));
 
             const nodes = await Promise.all(threadIds.map((id) => this.miDebugger.sendCommand(`thread-info ${id}`)));
 
@@ -971,7 +1134,7 @@ export class GDBDebugSession extends DebugSession {
             const stack = await this.miDebugger.getStack(args.threadId, args.startFrame, args.levels);
             const ret: StackFrame[] = [];
             for (const element of stack) {
-                const stackId = (args.threadId << 8 | (element.level & 0xFF)) & 0xFFFF;
+                const stackId = GDBDebugSession.encodeReference(args.threadId, element.level);
                 const file = element.file;
                 let disassemble = this.forceDisassembly || !file;
                 if (!disassemble) { disassemble = !(await this.checkFileExists(file)); }
@@ -1063,7 +1226,7 @@ export class GDBDebugSession extends DebugSession {
                 const varObjName = `global_var_${symbol.name}`;
                 let varObj: VariableObject;
                 try {
-                    const changes = await this.miDebugger.varUpdate(varObjName);
+                    const changes = await this.miDebugger.varUpdate(varObjName, -1, -1);
                     const changelist = changes.result('changelist');
                     changelist.forEach((change) => {
                         const name = MINode.valueOf(change, 'name');
@@ -1114,7 +1277,7 @@ export class GDBDebugSession extends DebugSession {
                 const varObjName = `${file}_static_var_${symbol.name}`;
                 let varObj: VariableObject;
                 try {
-                    const changes = await this.miDebugger.varUpdate(varObjName);
+                    const changes = await this.miDebugger.varUpdate(varObjName, -1, -1);
                     const changelist = changes.result('changelist');
                     changelist.forEach((change) => {
                         const name = MINode.valueOf(change, 'name');
@@ -1169,22 +1332,25 @@ export class GDBDebugSession extends DebugSession {
         return varObj.isCompound() ? id : 0;
     }
 
+    protected createStackVarName(name: string, varRef: number) {
+        return `var_${name}_${varRef}`;
+    }
+
     private async stackVariablesRequest(
-        threadId: number,
-        frameId: number,
         response: DebugProtocol.VariablesResponse,
         args: DebugProtocol.VariablesArguments
     ): Promise<void> {
+        const [threadId, frameId] = GDBDebugSession.decodeReference(args.variablesReference);
         const variables: DebugProtocol.Variable[] = [];
         let stack: Variable[];
         try {
             stack = await this.miDebugger.getStackVariables(threadId, frameId);
             for (const variable of stack) {
                 try {
-                    const varObjName = `var_${variable.name}`;
+                    const varObjName = this.createStackVarName(variable.name, args.variablesReference);
                     let varObj: VariableObject;
                     try {
-                        const changes = await this.miDebugger.varUpdate(varObjName);
+                        const changes = await this.miDebugger.varUpdate(varObjName, threadId, frameId);
                         const changelist = changes.result('changelist');
                         changelist.forEach((change) => {
                             const name = MINode.valueOf(change, 'name');
@@ -1197,7 +1363,8 @@ export class GDBDebugSession extends DebugSession {
                     }
                     catch (err) {
                         if (err instanceof MIError && err.message === 'Variable object not found') {
-                            varObj = await this.miDebugger.varCreate(variable.name, varObjName);
+                            // Create variable in current frame/thread context. Matters when we have to set the variable */
+                            varObj = await this.miDebugger.varCreate(variable.name, varObjName, '*');
                             const varId = this.findOrCreateVariable(varObj);
                             varObj.exp = variable.name;
                             varObj.id = varId;
@@ -1230,7 +1397,7 @@ export class GDBDebugSession extends DebugSession {
         // Variable members
         let variable;
         try {
-            variable = await this.miDebugger.evalExpression(JSON.stringify(id));
+            variable = await this.miDebugger.evalExpression(JSON.stringify(id), -1, -1);
             try {
                 let expanded = expandValue(this.createVariable.bind(this), variable.result('value'), id, variable);
                 if (!expanded) {
@@ -1268,14 +1435,11 @@ export class GDBDebugSession extends DebugSession {
             return this.globalVariablesRequest(response, args);
         }
         else if (args.variablesReference >= STATIC_HANDLES_START && args.variablesReference <= STATIC_HANDLES_FINISH) {
-            const frameId = args.variablesReference & 0xFF;
-            const threadId = (args.variablesReference & 0xFF00) >>> 8;
+            const [threadId, frameId] = GDBDebugSession.decodeReference(args.variablesReference);
             return this.staticVariablesRequest(threadId, frameId, response, args);
         }
         else if (args.variablesReference >= STACK_HANDLES_START && args.variablesReference < STACK_HANDLES_FINISH) {
-            const frameId = args.variablesReference & 0xFF;
-            const threadId = (args.variablesReference & 0xFF00) >>> 8;
-            return this.stackVariablesRequest(threadId, frameId, response, args);
+            return this.stackVariablesRequest(response, args);
         }
         else {
             id = this.variableHandles.get(args.variablesReference);
@@ -1328,7 +1492,7 @@ export class GDBDebugSession extends DebugSession {
                             this.sendResponse(response);
                         };
                         const addOne = async () => {
-                            const variable = await this.miDebugger.evalExpression(JSON.stringify(`${varReq.name}+${arrIndex})`));
+                            const variable = await this.miDebugger.evalExpression(JSON.stringify(`${varReq.name}+${arrIndex})`), -1, -1);
                             try {
                                 const expanded = expandValue(this.createVariable.bind(this), variable.result('value'), varReq.name, variable);
                                 if (!expanded) {
@@ -1391,8 +1555,8 @@ export class GDBDebugSession extends DebugSession {
         }
     }
 
-    protected pauseRequest(response: DebugProtocol.PauseResponse, args: DebugProtocol.ContinueArguments): void {
-        this.miDebugger.interrupt(args.threadId).then((done) => {
+    protected pauseRequest(response: DebugProtocol.PauseResponse, args: DebugProtocol.PauseArguments): void {
+        this.miDebugger.interrupt().then((done) => {
             this.sendResponse(response);
         }, (msg) => {
             this.sendErrorResponse(response, 3, `Could not pause: ${msg}`);
@@ -1488,6 +1652,12 @@ export class GDBDebugSession extends DebugSession {
     }
 
     protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): Promise<void> {
+        /*
+         * Expressions (watch/hover/REPL) should always be evaluated in the current context.  Unfortunately, we don't know
+         * what that is as the user is interacting with the call-stack window and VSCode caches some results. But it is
+         * passed in as part of 'args.frameId`. Bit of a misnomer, it has both the thread and frame id encoded into it
+         * when we originally created IDs for each frame.
+         */
         const createVariable = (arg, options?) => {
             if (options) {
                 return this.variableHandles.create(new ExtendedVariable(arg, options));
@@ -1509,6 +1679,14 @@ export class GDBDebugSession extends DebugSession {
             return varObj.isCompound() ? id : 0;
         };
 
+        // Spec says if 'frameId' is specified, evaluate in the scope specified or in the global scope. Well,
+        // we don't have a way to specify global scope ... use current thread then.
+        let threadId = this.currentThreadId;
+        let frameId = 0;
+        if (args.frameId) {     // Should always be valid
+            [threadId, frameId] = GDBDebugSession.decodeReference(args.frameId);
+        }
+
         if (args.context === 'watch') {
             try {
                 const exp = args.expression;
@@ -1518,7 +1696,7 @@ export class GDBDebugSession extends DebugSession {
                 const varObjName = `watch_${watchName}`;
                 let varObj: VariableObject;
                 try {
-                    const changes = await this.miDebugger.varUpdate(varObjName);
+                    const changes = await this.miDebugger.varUpdate(varObjName, threadId, frameId);
                     const changelist = changes.result('changelist');
                     changelist.forEach((change) => {
                         const name = MINode.valueOf(change, 'name');
@@ -1561,7 +1739,7 @@ export class GDBDebugSession extends DebugSession {
         }
         else if (args.context === 'hover') {
             try {
-                const res = await this.miDebugger.evalExpression(args.expression);
+                const res = await this.miDebugger.evalExpression(args.expression, threadId, frameId);
                 response.body = {
                     variablesReference: 0,
                     result: res.result('value')
@@ -1573,6 +1751,10 @@ export class GDBDebugSession extends DebugSession {
             }
         }
         else {
+            // REPL: Set the proper thread/frame context before sending command to gdb. We don't know
+            // what the command is but it needs to be run in the proper context.
+            this.miDebugger.sendCommand(`thread-select ${threadId}`);
+            this.miDebugger.sendCommand(`stack-select-frame ${frameId}`);
             this.miDebugger.sendUserInput(args.expression).then((output) => {
                 if (typeof output === 'undefined') {
                     response.body = {

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -1095,7 +1095,7 @@ export class GDBDebugSession extends DebugSession {
 
             for (const thId of threadIds) {
                 // Make sure VSCode knows about all the threads. GDB may still be in the process of notifying
-                // new threads while we already have a thread-list
+                // new threads while we already have a thread-list. Technically, this should never happen
                 this.handleThreadCreated({threadId: thId, threadGroupId: 'i1'});
             }
 

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -889,7 +889,7 @@ export class GDBDebugSession extends DebugSession {
         }
         if (!this.activeThreadIds.has(info.threadId)) {
             // We are seeing this happen. Not sure why and and can this event be relied upon?
-            this.handleMsg('log', `Thread Error: GDB trying to select thread '${info.threadId}' that does not exist.\n`);
+            this.handleMsg('log', `Thread Error: GDB trying to select thread '${info.threadId}' that does not exist. No harm done\n`);
         } else {
             this.currentThreadId = info.threadId;
         }

--- a/src/openocd.ts
+++ b/src/openocd.ts
@@ -118,6 +118,10 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
             serverargs.push('-s', this.args.cwd);
         }
 
+        for (const cmd of this.args.openOCDPreConfigLaunchCommands || []) {
+            serverargs.push('-c', cmd);
+        }
+
         this.args.configFiles.forEach((cf, idx) => {
             serverargs.push('-f', cf);
         });
@@ -145,15 +149,12 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
             commands.push(`tpiu config ${tpiuIntExt} uart off ${this.args.swoConfig.cpuFrequency} ${this.args.swoConfig.swoFrequency}`);
         }
 
-        // Append additional commands
-        if (this.args.openOCDLaunchCommands) {
-            this.args.openOCDLaunchCommands.forEach((cmd) => {
-                commands.push(cmd);
-            });
-        }
-        
         if (commands.length > 0) {
             serverargs.push('-c', commands.join('; '));
+        }
+
+        for (const cmd of this.args.openOCDLaunchCommands || []) {
+            serverargs.push('-c', cmd);
         }
 
         return serverargs;


### PR DESCRIPTION
Prologue: This would not have been easy if it wasn't for how well organized @Marus code structure is. Hoping I did not mess it up :-). Yeah, creating a multi-threaded debugger is not easy especially given that most gdb servers (JLink, OpenOCD) themselves don't comply/understand threads. I did not make accommodations for vendor/gdb-server bugs and we want to stick to the specs as close as possible. Test cases are hard to come by. I am hoping my changes leave us at a better place, albeit not perfect.

In this PR, there are a bunch of thread related fixes and a few unrelated changes. There was not one issue but a whole host of them that caused failures in various ways. I did tons of testing with OpenOCD (which has its own share of bugs) and some with JLink. While it may look like a lot of changes, 90+% are in gdb.ts. Should not affect anyone who is not doing thread-aware debugging.
- Thread management: Track thread creation/exiting better. Also, track thread-group-exited
- In `threadsRequest`, make sure we get the proper current thread based on a stopped event. Also, sync with gdb when gdb does not give us a current-thread. Some consistency checks as well. If we believe that VSCode has not been notified of the most recent current-thread, then do it. See below about next item.
- When an 'exec stopped' gdb notification happens, make sure we know which thread paused. Found out, this was actually super important to let VSCode know which thread actually paused or else visuals were wrong, call stack window focus/status was wrong and even debug button states (pause/continue, step, etc.) were wrong. Kinda had a chain reaction.
- When creating gdb-variables (global, static, local, watch), make sure proper thread context is used. Or else, we were displaying the wrong values.
- Fixed set variable so that it uses the proper thread context. Also, set-variable was broken because we now have to use the prefixed+hashed variable names rather than display names. Still have issues with setting static variables but everything else should work. Can address later.
- Fixed bug in mi-parser which was causing bad/missing information from gdb. We were not consuming a matching `}` or `]`. Affected thread info parsing and maybe other things.
- added thread related debug code (internal use only)
- When evaluating an expression (watch, REPL, hover), use the thread context supplied or else evaluating may fail or even worse, give wrong results.
- When VSCode makes a `pauseRequest`, it supplies a thread-id. Well, we can't really honor that. Unless I am reading the gdb-mi docs wrong no way to do that really, you can either say `--all` or `--thread-group`. While VSCode also gives a thread-id for a `continueRequest`, I did not change that. Have not seen failures. Most gdb servers ignore thread-id for a continue. So, status-quo for continue

Changes not related to threads. I should have made separate PRs for these but there were too many thread related changes that got intertwined, so doing this made my testing easier

- Added feature #197 for launch, attach and restart.
- Always print command lines for server and gdb starts. Eliminates many (support) issues trying to  figure out what is wrong w/o asking users to enable `showDevDebugOutput`
- Clear 'Adapter Output' window for a new debug session -- does not affect restart.
- OpenOCD: use separate '-c' commands instead of joining them with a `;`. There is a tiny semantic difference.
- OpenOCD: added a way to add commands before config files are loaded. Can' do many things once config files are loaded. Also added `openOCDPreConfigLaunchCommands` and the existing`openOCDLaunchCommands` to `package.json`
- When starting server, use the `cwd` instead of a random one.
- Cleaner detach/disconnect. Must -exec-interrupt when detaching if the target is running. Disconnect code now looks similar to restart code and a couple of other places where we needed to do an -exec-interrupt
- Disable sending events to VSCode when we are just starting or re-starting. Helps cut down on a bunch of gdb chatter and avoid issuing gdb commands that are not valid for a 'running' or 'stopped' state.
- Better message if SVD file is not found or has errors
- Fixed issue when a peripheral has no registers. Issue #208
- Some changes in tcpportscanner.ts that are for future use -- currently unused but may be needed for future.