### PR TITLE
Fix issue: Unable to view Static variables during debug

### DIFF
--- a/src/backend/symbols.ts
+++ b/src/backend/symbols.ts
@@ -89,7 +89,7 @@ export class SymbolTable {
     }
 
     public getStaticVariables(file: string): SymbolInformation[] {
-        return this.symbols.filter((s) => s.type === SymbolType.Object && s.scope === SymbolScope.Local && s.file === file);
+        return this.symbols.filter((s) => s.type === SymbolType.Object && s.scope === SymbolScope.Local && !s.name.includes(".") && (s.file === file || file.endsWith(`/${s.file}`)));
     }
 
     public getFunctionByName(name: string, file?: string): SymbolInformation {


### PR DESCRIPTION
There are two issues that lead to this situation:

In my case,  This function blew not doing the right job
``` typescript
public getStaticVariables(file: string): SymbolInformation[] {
    return this.symbols.filter((s) => s.type === SymbolType.Object && s.scope === SymbolScope.Local && !s.name.includes(".") && (s.file === file || file.endsWith(`/${s.file}`)));
}
``` 

First: The arg (file: string) format like `<file path>/<filename>`  and the s.file is just `<filename>`.

Second: Static local variables are compiled into `<var name>.<hash>` such as `foo.12521`,  The function `getStaticVariables` also include static local variable with error name in result list.