### PR TITLE
Webpack - Binary Module Loading Fix

### DIFF
--- a/src/frontend/swo/sources/serial.ts
+++ b/src/frontend/swo/sources/serial.ts
@@ -5,6 +5,9 @@ import * as os from 'os';
 import * as vscode from 'vscode';
 import * as path from 'path';
 
+declare function __webpack_require__(name: string): any;
+declare function __non_webpack_require__(name: string): any;
+
 export class SerialSWOSource extends EventEmitter implements SWOSource {
     private serialPort: any = null;
     public connected: boolean = false;
@@ -20,7 +23,8 @@ export class SerialSWOSource extends EventEmitter implements SWOSource {
 
         let SerialPort;
         try {
-            SerialPort = module.require('serialport');
+            const requireFunc = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require;
+            SerialPort = requireFunc('serialport');
         }
         catch (e) {
             // tslint:disable-next-line:max-line-length


### PR DESCRIPTION
This should fix loading of the binary modules for the serial port when webpack has been completed. Webpack normally replaces the require method - but you can access it using the _non_webpack_require__ method (which becomes regular require when packed). This change conditionally uses with require or __non_webpack_require__ depending on if it is being used in a webpack context.