### PR TITLE
Setup the external interafce to allow for port forwarded ITM

### DIFF
--- a/src/external.ts
+++ b/src/external.ts
@@ -78,7 +78,19 @@ export class ExternalServerController extends EventEmitter implements GDBServerC
     }
 
     public serverLaunchStarted(): void {}
-    public serverLaunchCompleted(): void {}
+    public serverLaunchCompleted(): void {
+        if (this.args.swoConfig.enabled) {
+            if (this.args.swoConfig.source === 'probe' && os.platform() === 'win32') {
+                this.emit('event', new SWOConfigureEvent({ type: 'file', path: this.swoPath }));
+            }
+            else if (this.args.swoConfig.source !== 'probe') {
+                this.emit('event', new SWOConfigureEvent({
+                    type: 'fifo',
+                    path: this.args.swoConfig.swoPath
+                }));
+            }
+        }
+    }
     public debuggerLaunchStarted(): void {}
     public debuggerLaunchCompleted(): void {}
 }

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -274,11 +274,11 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
     }
 
     private verifyExternalConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration): string {
-        if (config.swoConfig.enabled && config.swoConfig.source === 'probe') {
-            vscode.window.showWarningMessage('SWO support is not available for external GDB servers. Disabling SWO support.');
-            config.swoConfig = { enabled: false, ports: [], cpuFrequency: 0, swoFrequency: 0 };
-            config.graphConfig = [];
-        }
+//        if (config.swoConfig.enabled && config.swoConfig.source === 'probe') {
+//            vscode.window.showWarningMessage('SWO support is not available for external GDB servers. Disabling SWO support.');
+//            config.swoConfig = { enabled: false, ports: [], cpuFrequency: 0, swoFrequency: 0 };
+//            config.graphConfig = [];
+//        }
 
         if (!config.gdbTarget) {
             return 'External GDB server type must specify the GDB target. This should either be a "hostname:port" combination or a serial port.';


### PR DESCRIPTION
Currently, the external interface is quite limited when it comes to the access to the debugging information.  I this PR, I have very naively I might add (maybe not a good approach), made it to where I can access the ITM data being forwarded from my Raspberry Pi using the `scout` application.  Below I show the steps that I used to have a fully working and disconnected debugging session with ITM through the Cortex-Debug extension.  After that workflow is described, I discuss divorcing of the SWO configuration from the GDB interface.  

# Current Execution Workflow

Specifically, here are my steps:
1: ssh into the Raspberry Pi and set my UART to 115200 (cannot seem to get good dependable higher speed access, I plan to work on that some more) and then fire off the `socat` application.

```bash
#!/bin/sh

stty -F /dev/ttyAMA0 115200
socat /dev/ttyAMA0,raw,echo=0 tcp-listen:8888,reuseaddr
```

2: SSH into the Raspberry Pi again and fire off OpenOCD using a local configuration file.  I had to manually adjust the registers to get the ITM port working when using the Raspberry Pi interface to the Microcontroller vice a more standard ST-LINK V2 which I am used to using.  The OpenOCD configuration file is:

```
source [find interface/raspberrypi2-native.cfg]
transport select swd
 
set CHIPNAME stm32
source [find target/stm32f1x.cfg]
  
adapter srst delay 100
adapter srst pulse_width 100

bindto 0.0.0.0
 
init
targets
reset halt

# The following command does not work (limitation with using the raspberrypi2-native.cfg interface
tpiu config external uart off 72000000 2000000

mww phys 0xE000EDFC 0x01000000
mwb phys 0xE0042004 0x27
mwb phys 0xE00400F0 2

# 115200
# The below prescaler value is based on a SYSCLK of 72MHz to get 115200.
mww phys 0xE0040010 625
mww phys 0xE0000FB0 0xC5ACCE55
mww phys 0xE0000E80 0x0001000D
mwb phys 0xE0000E40 0x0000000F
mwb phys 0xE0000E00 0x1
```

3: I then use a different `socat` invocation on my local machine to open up a port:

```bash
#!/bin/sh

socat PTY,raw,echo=0,link=/dev/ttyVUSB0 tcp:192.168.1.199:8888
```

4: Change the permissions of `/dev/ttyVUSB0` to 777

```
# sudo chmod 777 /dev/ttyVUSB0
```

5: Configure the Cortex-Debug addin to use it all:

```
        {
            "type": "cortex-debug",
            "request": "launch",
            "servertype": "external",
            "gdbTarget": "192.168.1.199:3333",
            "armToolchainPath": "/usr/local/bin",
            "cwd": "/Users/justaceclutter/Desktop/GermanEqualateralMount/Code/stm32_motor_driver",
            "executable": "./target/thumbv7m-none-eabi/release/stm32_motor_driver",
            "name": "Release (RPi) [Launch]",
            "swoConfig": {
                "enabled": true,
                "source": "fifo",
                "swoPath": "/dev/ttyVUSB0",
                "decoders": [
                    { "type": "console", "label": "ITM", "port": 0 }
                ]
            },
            "showDevDebugOutput": true,
            "device": "STM32F103C8"
        }

```

6: Enjoy your laptop like it should be, disconnected....  ;)

# Approach to SWO configuration

I will start by saying that I do not know TypeScript and therefore have a hard time following the organization of the extension code.  With this limitation, I was able to still see that the SWO configurtation is directly tied to the mechanism by which GDB is used.  

For instance, the extension explicitly removes SWO configuration from the external interface, even if one tries to set it up.  This twarted my efforts to use a forwarded TTY for the SWO, and is the source of this PR. 

Based in this experiance, I recommend that the SWO configuration be divorced from the GDB access method.  Leave it up to the end user to provide a conduit by which the SWO data can arrive and then provide them with the necessary linkages to access that pipeline.  I noticed that currently, there are SWO access methods for `File`, `Fifo`, `Socket`, `Serial`.  That is a very flexable set of tools.  Unfortunatly, the end user cannot access them.  My suggestion would be to expose these to the end user and let them configure them as necessary.  The configuration could look like the following:

```
        {
            "type": "cortex-debug",
            "name": "Release (RPi) [Launch]",
            "GDBConfig": {
                "request": "launch",
                "servertype": "external",
                "gdbTarget": "192.168.1.199:3333",
                "armToolchainPath": "/usr/local/bin",
                "cwd": "/Users/justaceclutter/Desktop/GermanEqualateralMount/Code/stm32_motor_driver",
                "executable": "./target/thumbv7m-none-eabi/release/stm32_motor_driver"
                "device": "STM32F103C8"
                "showDevDebugOutput": true,
            },
            "swoConfig": {
                "enabled": true,
                "source": "fifo",
                "swoPath": "/dev/ttyVUSB0",
                "decoders": [
                    { "type": "console", "label": "ITM", "port": 0 }
                ]
            },
        }
```

In this way, the user is provided with a huge amount of flexability.  All of the code seems in place for this.  It just needs to be exposed and glued.

Thoughts?



