### PR TITLE
Preparation for Version 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Minor bug fix release
    * Support for IAR produced elf files which just did not work with V0.3.6. They didn't quite work with earlier releases either. They are non-standard (kinda) compared to what gcc produced or what objdump documents
    * With the latest version of VSCode, there were too many popups coming. They are all harmless, but annoying. There were changed made to suppress these but they caused other problems. We may just have to live with those popups (that are non-modal and disappear after a while) until we figure out how VSCode has changed. May take a while
 2. Issues Fixed
-   * Fixed Issue [#273](https://github.com/Marus/cortex-debug/issues/273). Handle peripherals blocks with no addressBlocks.
+   * Fixed Issue [#273](https://github.com/Marus/cortex-debug/issues/273). Handle peripherals blocks with no addressBlocks. Also fix issue with multiple address blocks where only the first one was being used
    * Fixed Issue [#284](https://github.com/Marus/cortex-debug/issues/284). Implement/support 'derivedFrom' at register level.
    * When runToMain was enabled there were 1-2 harmless popups when the program stopped in main. They were very frequent on Windows, less frequent on Linux and very rare if any on a Mac.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Minor bug fix release
    * With the latest version of VSCode, there were too many popups coming. They are all harmless, but annoying. There were changed made to suppress these but they caused other problems. We may just have to live with those popups (that are non-modal and disappear after a while) until we figure out how VSCode has changed. May take a while
 2. Issues Fixed
    * Fixed Issue [#273](https://github.com/Marus/cortex-debug/issues/273). Handle peripherals blocks with no addressBlocks.
+   * Fixed Issue [#284](https://github.com/Marus/cortex-debug/issues/284). Implement/support 'derivedFrom' at register level.
    * When runToMain was enabled there were 1-2 harmless popups when the program stopped in main. They were very frequent on Windows, less frequent on Linux and very rare if any on a Mac.
 
 # V0.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# V0.3.7
+Minor bug fix release
+
+1. New feature
+   * Support for IAR produced elf files which just did not work with V0.3.6. They didn't quite work with earlier releases either. They are non-standard (kinda) compared to what gcc produced or what objdump documents
+   * With the latest version of VSCode, there were too many popups coming. They are all harmless, but annoying. There were changed made to suppress these but they caused other problems. We may just have to live with those popups (that are non-modal and disappear after a while) until we figure out how VSCode has changed. May take a while
+2. Issues Fixed
+   * Fixed Issue [#273](https://github.com/Marus/cortex-debug/issues/273). Handle peripherals blocks with no addressBlocks.
+   * When runToMain was enabled there were 1-2 harmless popups when the program stopped in main. They were very frequent on Windows, less frequent on Linux and very rare if any on a Mac.
+
 # V0.3.6
 
 Minor bug fix release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Minor bug fix release
 2. Issues Fixed
    * Fixed Issue [#273](https://github.com/Marus/cortex-debug/issues/273). Handle peripherals blocks with no addressBlocks. Also fix issue with multiple address blocks where only the first one was being used
    * Fixed Issue [#284](https://github.com/Marus/cortex-debug/issues/284). Implement/support 'derivedFrom' at register level.
+   * Fixed Issue [#306](https://github.com/Marus/cortex-debug/issues/306). Support displaying more than 20 stack frames
    * When runToMain was enabled there were 1-2 harmless popups when the program stopped in main. They were very frequent on Windows, less frequent on Linux and very rare if any on a Mac.
 
 # V0.3.6

--- a/package.json
+++ b/package.json
@@ -1561,5 +1561,5 @@
         "compile": "webpack --mode development",
         "test-compile": "tsc -p ./"
     },
-    "version": "0.3.7-pre1"
+    "version": "0.3.7-pre2"
 }

--- a/package.json
+++ b/package.json
@@ -454,6 +454,11 @@
                                 "description": "Prints all GDB responses to the console",
                                 "type": "boolean"
                             },
+                            "showDevDebugTimestamps": {
+                                "default": false,
+                                "description": "Show timestamps when 'showDevDebugOutput' is true",
+                                "type": "boolean"
+                            },
                             "svdFile": {
                                 "default": null,
                                 "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.",
@@ -1025,6 +1030,11 @@
                                 "description": "Prints all GDB responses to the console",
                                 "type": "boolean"
                             },
+                            "showDevDebugTimestamps": {
+                                "default": false,
+                                "description": "Show timestamps when 'showDevDebugOutput' is true",
+                                "type": "boolean"
+                            },
                             "svdFile": {
                                 "default": null,
                                 "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.",
@@ -1561,5 +1571,5 @@
         "compile": "webpack --mode development",
         "test-compile": "tsc -p ./"
     },
-    "version": "0.3.7-pre2"
+    "version": "0.3.7-pre3"
 }

--- a/package.json
+++ b/package.json
@@ -1561,5 +1561,5 @@
         "compile": "webpack --mode development",
         "test-compile": "tsc -p ./"
     },
-    "version": "0.3.6"
+    "version": "0.3.7-pre1"
 }

--- a/package.json
+++ b/package.json
@@ -1571,5 +1571,5 @@
         "compile": "webpack --mode development",
         "test-compile": "tsc -p ./"
     },
-    "version": "0.3.7-pre3"
+    "version": "0.3.7-pre4"
 }

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -456,6 +456,19 @@ export class MI2 extends EventEmitter implements IBackend {
         });
     }
 
+    public getStackDepth(threadId: number): Thenable<number> {
+        if (trace) {
+            this.log('stderr', 'getStackDepth');
+        }
+        return new Promise((resolve, reject) => {
+            this.sendCommand(`stack-info-depth --thread ${threadId} 10000`).then((result) => {
+                const depth = result.result('depth');
+                const ret = parseInt(depth);
+                resolve(ret);
+            }, reject);
+        });
+    }
+
     public getStack(threadId: number, startLevel: number, maxLevels: number): Thenable<Stack[]> {
         if (trace) {
             this.log('stderr', 'getStack');

--- a/src/backend/symbols.ts
+++ b/src/backend/symbols.ts
@@ -7,7 +7,7 @@ import * as crypto from 'crypto';
 
 import { SymbolType, SymbolScope, SymbolInformation } from '../symbols';
 
-const SYMBOL_REGEX = /\n([0-9a-f]{8})\s([lg\ !])([w\ ])([C\ ])([W\ ])([I\ ])([dD\ ])([FfO\ ])\s([^\s]+)\s([^\s]*\s)?([0-9a-f]+)\s([^\r\n]*)/mg;
+const SYMBOL_REGEX = /\n([0-9a-f]{8})\s([lg\ !])([w\ ])([C\ ])([W\ ])([I\ ])([dD\ ])([FfO\ ])\s(.*?)\s+([0-9a-f]+)\s([^\r\n]+)/mg;
 // DW_AT_name && DW_AT_comp_dir may have optional stuff that looks like '(indirect string, offset: 0xf94): '
 const COMP_UNIT_REGEX = /\n <0>.*\(DW_TAG_compile_unit\)[\s\S]*?DW_AT_name[\s]*: (\(.*\):\s)?(.*)[\r\n]+([\s\S]*?)\n </mg;
 // DW_AT_comp_dir may not exist
@@ -104,8 +104,8 @@ export class SymbolTable {
             let match: RegExpExecArray;
             while ((match = regex.exec(str)) !== null) {
                 if (match[7] === 'd' && match[8] === 'f') {
-                    if (match[12]) {
-                        currentFile = SymbolTable.NormalizePath(match[12].trim());
+                    if (match[11]) {
+                        currentFile = SymbolTable.NormalizePath(match[11].trim());
                     } else {
                         // This can happen with C++. Inline and template methods/variables/functions/etc. are listed with
                         // an empty file association. So, symbols after this line can come from multiple compilation
@@ -115,7 +115,7 @@ export class SymbolTable {
                 }
                 const type = TYPE_MAP[match[8]];
                 const scope = SCOPE_MAP[match[2]];
-                let name = match[12].trim();
+                let name = match[11].trim();
                 let hidden = false;
 
                 if (name.startsWith('.hidden')) {

--- a/src/backend/symbols.ts
+++ b/src/backend/symbols.ts
@@ -7,8 +7,11 @@ import * as crypto from 'crypto';
 
 import { SymbolType, SymbolScope, SymbolInformation } from '../symbols';
 
-const SYMBOL_REGEX = /\n([0-9a-f]{8})\s([lg\ !])([w\ ])([C\ ])([W\ ])([I\ ])([dD\ ])([FfO\ ])\s([^\s]+)\s([0-9a-f]+)\s([^\r\n]*)/mg;
-const COMP_UNIT_REGEX = /\n <0>.*\(DW_TAG_compile_unit\)[\s\S]*?DW_AT_name[\s\S]*?\)\: (\S*)[\r\n]+[\s\S]*?DW_AT_comp_dir[\s\S]*?\)\: (\S*)[\r\n]+/mg;
+const SYMBOL_REGEX = /\n([0-9a-f]{8})\s([lg\ !])([w\ ])([C\ ])([W\ ])([I\ ])([dD\ ])([FfO\ ])\s([^\s]+)\s([^\s]*\s)?([0-9a-f]+)\s([^\r\n]*)/mg;
+// DW_AT_name && DW_AT_comp_dir may have optional stuff that looks like '(indirect string, offset: 0xf94): '
+const COMP_UNIT_REGEX = /\n <0>.*\(DW_TAG_compile_unit\)[\s\S]*?DW_AT_name[\s]*: (\(.*\):\s)?(.*)[\r\n]+([\s\S]*?)\n </mg;
+// DW_AT_comp_dir may not exist
+const COMP_DIR_REGEX = /DW_AT_comp_dir[\s]*: (\(.*\):\s)?(.*)[\r\n]+/m;
 const debugConsoleLogging = false;
 
 const TYPE_MAP: { [id: string]: SymbolType } = {
@@ -101,8 +104,8 @@ export class SymbolTable {
             let match: RegExpExecArray;
             while ((match = regex.exec(str)) !== null) {
                 if (match[7] === 'd' && match[8] === 'f') {
-                    if (match[11]) {
-                        currentFile = SymbolTable.NormalizePath(match[11].trim());
+                    if (match[12]) {
+                        currentFile = SymbolTable.NormalizePath(match[12].trim());
                     } else {
                         // This can happen with C++. Inline and template methods/variables/functions/etc. are listed with
                         // an empty file association. So, symbols after this line can come from multiple compilation
@@ -112,7 +115,7 @@ export class SymbolTable {
                 }
                 const type = TYPE_MAP[match[8]];
                 const scope = SCOPE_MAP[match[2]];
-                let name = match[11].trim();
+                let name = match[12].trim();
                 let hidden = false;
 
                 if (name.startsWith('.hidden')) {
@@ -248,12 +251,16 @@ export class SymbolTable {
                     if (end > match.index) {
                         end = match.index;
                     }
-                    const curName = SymbolTable.NormalizePath(match[1]);
+                    const curName = SymbolTable.NormalizePath(match[2]);
                     const curSimpleName = path.basename(curName);
                     this.addToFileMap(curSimpleName, curSimpleName);
                     this.addToFileMap(curSimpleName, curName);
-                    // Do not use path.join below. Match[2] can be in non-native form. Will be fixed by addToFileMap
-                    this.addToFileMap(curSimpleName, match[2] + '/' + curName);
+                    const compDir = RegExp(COMP_DIR_REGEX);
+                    match = compDir.exec(match[3]);
+                    if (match) {
+                        // Do not use path.join below. Match[1] can be in non-native form. Will be fixed by addToFileMap
+                        this.addToFileMap(curSimpleName, match[2] + '/' + curName);
+                    }
                     counter++;
                 }
                 const diff = Date.now() - start;

--- a/src/common.ts
+++ b/src/common.ts
@@ -108,6 +108,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     swoConfig: SWOConfiguration;
     graphConfig: any[];
     showDevDebugOutput: boolean;
+    showDevDebugTimestamps: boolean;
     cwd: string;
     extensionPath: string;
     rtos: string;

--- a/src/frontend/svd.ts
+++ b/src/frontend/svd.ts
@@ -72,7 +72,12 @@ export class SVDParser {
                     const peripherials = [];
                     // tslint:disable-next-line:forin
                     for (const key in peripheralMap) {
-                        peripherials.push(SVDParser.parsePeripheral(peripheralMap[key], defaultOptions));
+                        try {
+                            peripherials.push(SVDParser.parsePeripheral(peripheralMap[key], defaultOptions));
+                        }
+                        catch (msg) {
+                            reject(msg);
+                        }
                     }
 
                     peripherials.sort((p1, p2) => {
@@ -349,12 +354,12 @@ export class SVDParser {
     }
 
     private static parsePeripheral(p: any, defaults: { accessType: AccessType, size: number, resetValue: number }): PeripheralNode {
-        const ab = p.addressBlock[0];
-        const totalLength = parseInteger(ab.size[0]);
+        const ab = p.addressBlock ? p.addressBlock[0] : null;
+        const totalLength = parseInteger(ab ? ab.size[0] : 0);
         
         const options: any = {
             name: p.name[0],
-            baseAddress: parseInteger(p.baseAddress[0]),
+            baseAddress: parseInteger(p.baseAddress ? p.baseAddress[0] : 0),
             description: this.cleanupDescription(p.description ? p.description[0] : ''),
             totalLength: totalLength
         };

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -1099,8 +1099,8 @@ export class GDBDebugSession extends DebugSession {
             if (this.stopped) { await createBreakpoints(false); }
             else {
                 this.disableSendStoppedEvents = true;
-                this.miDebugger.sendCommand('exec-interrupt');
                 this.miDebugger.once('generic-stopped', () => { createBreakpoints(true); });
+                this.miDebugger.sendCommand('exec-interrupt');
             }
         };
 
@@ -1197,8 +1197,8 @@ export class GDBDebugSession extends DebugSession {
             }
             else {
                 this.disableSendStoppedEvents = true;
-                await this.miDebugger.sendCommand('exec-interrupt');
                 this.miDebugger.once('generic-stopped', () => { createBreakpoints(true); });
+                this.miDebugger.sendCommand('exec-interrupt');
             }
         };
 

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -168,8 +168,9 @@ export class GDBDebugSession extends DebugSession {
 
     private launchAttachInit(args: ConfigurationArguments) {
         this.args = this.normalizeArguments(args);
-        // this.dbgSymbolStuff(args, 0);
-        // this.dbgSymbolStuff(args, 1);
+        // this.dbgSymbolStuff(args, '/Users/hdm/Downloads/firmware.elf', 'sty_uart_init_helper', 'mods/machine_uart.c');
+        // this.dbgSymbolStuff(args, '/Users/hdm/Downloads/bme680-driver-design_585.out', 'setup_bme680', './src/bme680_test_app.c');
+        // this.dbgSymbolStuff(args, '/Users/hdm/Downloads/test.out', 'BSP_Delay', 'C:/Development/GitRepos/Firmware/phoenix/STM32F4/usb_bsp.c');
         if (this.args.showDevDebugOutput) {
             this.handleMsg('log', `Reading symbols from '${args.executable}'\n`);
         }
@@ -183,11 +184,8 @@ export class GDBDebugSession extends DebugSession {
         this.fileExistsCache = new Map();
     }
 
-    private dbgSymbolStuff(args: ConfigurationArguments, testCase: number) {
+    private dbgSymbolStuff(args: ConfigurationArguments, elfFile: string, func: string, file: string) {
         if (os.userInfo().username === 'hdm') {
-            const elfFile = (testCase === 0) ? '/Users/hdm/Downloads/firmware.elf' : '/Users/hdm/Downloads/bme680-driver-design_585.out';
-            const func = (testCase === 0) ? 'sty_uart_init_helper' : 'setup_bme680';
-            const file = (testCase === 0) ? 'mods/machine_uart.c' : './src/bme680_test_app.c';
             this.handleMsg('log', `Reading symbols from ${elfFile}\n`);
             const tmpSymbols = new SymbolTable(args.toolchainPath, args.toolchainPrefix, elfFile, true);
             tmpSymbols.loadSymbols();

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -1304,7 +1304,9 @@ export class GDBDebugSession extends DebugSession {
 
     protected async stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments): Promise<void> {
         try {
-            const stack = await this.miDebugger.getStack(args.threadId, args.startFrame, args.levels);
+            const maxDepth = await this.miDebugger.getStackDepth(args.threadId);
+            const highFrame = Math.min(maxDepth, args.startFrame + args.levels) - 1;
+            const stack = await this.miDebugger.getStack(args.threadId, args.startFrame, highFrame);
             const ret: StackFrame[] = [];
             for (const element of stack) {
                 const stackId = GDBDebugSession.encodeReference(args.threadId, element.level);
@@ -1359,7 +1361,8 @@ export class GDBDebugSession extends DebugSession {
             }
 
             response.body = {
-                stackFrames: ret
+                stackFrames: ret,
+                totalFrames: maxDepth
             };
             this.sendResponse(response);
         }

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -852,7 +852,7 @@ export class GDBDebugSession extends DebugSession {
 
     protected timeStart = Date.now();
     protected wrapTimeStamp(str: string): string {
-        if (this.args.showDevDebugOutput) {
+        if (this.args.showDevDebugOutput && this.args.showDevDebugTimestamps) {
             const elapsed = Date.now() - this.timeStart;
             let elapsedStr = elapsed.toString();
             while (elapsedStr.length < 10) { elapsedStr = '0' + elapsedStr ; }


### PR DESCRIPTION
From the ChangeLog...

Minor bug fix release

1. New feature
   * Support for IAR produced elf files which just did not work with V0.3.6. They didn't quite work with earlier releases either. They are non-standard (kinda) compared to what gcc produced or what objdump documents
   * With the latest version of VSCode, there were too many popups coming. They are all harmless, but annoying. There were changed made to suppress these but they caused other problems. We may just have to live with those popups (that are non-modal and disappear after a while) until we figure out how VSCode has changed. May take a while
2. Issues Fixed
   * Fixed Issue [#273](https://github.com/Marus/cortex-debug/issues/273). Handle peripherals blocks with no addressBlocks. Also fix issue with multiple address blocks where only the first one was being used
   * Fixed Issue [#284](https://github.com/Marus/cortex-debug/issues/284). Implement/support 'derivedFrom' at register level.
   * Fixed Issue [#306](https://github.com/Marus/cortex-debug/issues/306). Support displaying more than 20 stack frames
   * When runToMain was enabled there were 1-2 harmless popups when the program stopped in main. They were very frequent on Windows, less frequent on Linux and very rare if any on a Mac.