### PR TITLE
Eight Bit Register support & Refresh on update peripheral register

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cortex-debug",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/frontend/views/nodes/peripheralclusternode.ts
+++ b/src/frontend/views/nodes/peripheralclusternode.ts
@@ -25,7 +25,7 @@ export class PeripheralClusterNode extends PeripheralBaseNode {
     public readonly resetValue: number;
     public readonly accessType: AccessType;
     public currentValue: number;
-    public tempValue: number[];
+    public currentValueArray: number[];
 
     constructor(public parent: PeripheralNode, options: ClusterOptions) {
         super(parent);

--- a/src/frontend/views/nodes/peripheralclusternode.ts
+++ b/src/frontend/views/nodes/peripheralclusternode.ts
@@ -24,6 +24,8 @@ export class PeripheralClusterNode extends PeripheralBaseNode {
     public readonly size: number;
     public readonly resetValue: number;
     public readonly accessType: AccessType;
+    public currentValue: number;
+    public tempValue: number[];
 
     constructor(public parent: PeripheralNode, options: ClusterOptions) {
         super(parent);

--- a/src/frontend/views/nodes/peripheralnode.ts
+++ b/src/frontend/views/nodes/peripheralnode.ts
@@ -102,27 +102,12 @@ export class PeripheralNode extends PeripheralBaseNode {
         return new Promise((resolve, reject) => {
             if (!this.expanded) { resolve(false); return; }
 
-
             const promises = this.children.map(r => {
-                let promise = MemReadUtils.readMemory(this.baseAddress+r.offset, r.size/8, r.tempValue);
+                let promise = MemReadUtils.readMemory(this.baseAddress+r.offset, r.size/8, r.currentValueArray);
                 promise.then(() => r.updateData(), ()=>{});
                 return promise;
             })
-            return Promise.all(promises).then(() => resolve(true), reject);
-            this.readMemory().then((unused) => {
-                const promises = this.children.map((r) => r.updateData());
-
-                Promise.all(promises).then((_) => {
-                    resolve(true);
-                }).catch((e) => {
-                    const msg = e.message || 'unknown error';
-                    const str = `Failed to update peripheral ${this.name}: ${msg}`;
-                    if (vscode.debug.activeDebugConsole) {
-                        vscode.debug.activeDebugConsole.appendLine(str);
-                    }
-                    reject(new Error(str));
-                });
-            }, (e) => {
+            return Promise.all(promises).then(() => resolve(true)).catch(e => {
                 const msg = e.message || 'unknown error';
                 const str = `Failed to update peripheral ${this.name}: ${msg}`;
                 if (vscode.debug.activeDebugConsole) {

--- a/src/frontend/views/nodes/peripheralnode.ts
+++ b/src/frontend/views/nodes/peripheralnode.ts
@@ -105,8 +105,10 @@ export class PeripheralNode extends PeripheralBaseNode {
             for(let reg of this.children){
                 MemReadUtils.readMemory(this.baseAddress+reg.offset, reg.size/8, reg.tempValue).then((unused) => {
                     console.log(reg.tempValue);
+                    reg.updateData();
                 });
             }
+            return;
             this.readMemory().then((unused) => {
                 const promises = this.children.map((r) => r.updateData());
 

--- a/src/frontend/views/nodes/peripheralnode.ts
+++ b/src/frontend/views/nodes/peripheralnode.ts
@@ -102,6 +102,11 @@ export class PeripheralNode extends PeripheralBaseNode {
         return new Promise((resolve, reject) => {
             if (!this.expanded) { resolve(false); return; }
 
+            for(let reg of this.children){
+                MemReadUtils.readMemory(this.baseAddress+reg.offset, reg.size/8, reg.tempValue).then((unused) => {
+                    console.log(reg.tempValue);
+                });
+            }
             this.readMemory().then((unused) => {
                 const promises = this.children.map((r) => r.updateData());
 

--- a/src/frontend/views/nodes/peripheralnode.ts
+++ b/src/frontend/views/nodes/peripheralnode.ts
@@ -102,13 +102,13 @@ export class PeripheralNode extends PeripheralBaseNode {
         return new Promise((resolve, reject) => {
             if (!this.expanded) { resolve(false); return; }
 
-            for(let reg of this.children){
-                MemReadUtils.readMemory(this.baseAddress+reg.offset, reg.size/8, reg.tempValue).then((unused) => {
-                    console.log(reg.tempValue);
-                    reg.updateData();
-                });
-            }
-            return;
+
+            const promises = this.children.map(r => {
+                let promise = MemReadUtils.readMemory(this.baseAddress+r.offset, r.size/8, r.tempValue);
+                promise.then(() => r.updateData(), ()=>{});
+                return promise;
+            })
+            return Promise.all(promises).then(() => resolve(true), reject);
             this.readMemory().then((unused) => {
                 const promises = this.children.map((r) => r.updateData());
 

--- a/src/frontend/views/nodes/peripheralregisternode.ts
+++ b/src/frontend/views/nodes/peripheralregisternode.ts
@@ -27,7 +27,7 @@ export class PeripheralRegisterNode extends PeripheralBaseNode {
     public readonly size: number;
     public readonly resetValue: number;
     public currentValue: number;
-    public tempValue: number[];
+    public currentValueArray: number[];
 
     private maxValue: number;
     private hexLength: number;
@@ -44,7 +44,7 @@ export class PeripheralRegisterNode extends PeripheralBaseNode {
         this.size = options.size || parent.size;
         this.resetValue = options.resetValue !== undefined ? options.resetValue : parent.resetValue;
         this.currentValue = this.resetValue;
-        this.tempValue = [];
+        this.currentValueArray = [];
         this.hexLength = Math.ceil(this.size / 4);
         
         this.maxValue = Math.pow(2, this.size);
@@ -185,7 +185,7 @@ export class PeripheralRegisterNode extends PeripheralBaseNode {
 
     public updateData(): Thenable<boolean> {
         const bc = this.size / 8;
-        const bytes = this.tempValue;
+        const bytes = this.currentValueArray;
         const buffer = Buffer.from(bytes);
         switch (bc) {
             case 1:

--- a/src/frontend/views/nodes/peripheralregisternode.ts
+++ b/src/frontend/views/nodes/peripheralregisternode.ts
@@ -15,6 +15,7 @@ export interface PeripheralRegisterOptions {
     accessType?: AccessType;
     size?: number;
     resetValue?: number;
+    currentValue?: number;
 }
 
 export class PeripheralRegisterNode extends PeripheralBaseNode {
@@ -25,12 +26,13 @@ export class PeripheralRegisterNode extends PeripheralBaseNode {
     public readonly accessType: AccessType;
     public readonly size: number;
     public readonly resetValue: number;
-    
+    public currentValue: number;
+    public tempValue: number[];
+
     private maxValue: number;
     private hexLength: number;
     private hexRegex: RegExp;
     private binaryRegex: RegExp;
-    private currentValue: number;
     
     constructor(public parent: PeripheralNode | PeripheralClusterNode, options: PeripheralRegisterOptions) {
         super(parent);
@@ -42,7 +44,7 @@ export class PeripheralRegisterNode extends PeripheralBaseNode {
         this.size = options.size || parent.size;
         this.resetValue = options.resetValue !== undefined ? options.resetValue : parent.resetValue;
         this.currentValue = this.resetValue;
-
+        this.tempValue = [];
         this.hexLength = Math.ceil(this.size / 4);
         
         this.maxValue = Math.pow(2, this.size);

--- a/src/frontend/views/nodes/peripheralregisternode.ts
+++ b/src/frontend/views/nodes/peripheralregisternode.ts
@@ -174,8 +174,11 @@ export class PeripheralRegisterNode extends PeripheralBaseNode {
 
         return new Promise((resolve, reject) => {
             debug.activeDebugSession.customRequest('write-memory', { address: address, data: bytes.join('') }).then((result) => {
-                this.parent.updateData().then(() => {}, () => {});
-                resolve(true);
+                this.parent.updateData().then(() => {
+                    resolve(true)
+                }, () => {
+                    resolve(true)
+                });
             }, reject);
         });
     }

--- a/src/frontend/views/nodes/peripheralregisternode.ts
+++ b/src/frontend/views/nodes/peripheralregisternode.ts
@@ -182,7 +182,7 @@ export class PeripheralRegisterNode extends PeripheralBaseNode {
 
     public updateData(): Thenable<boolean> {
         const bc = this.size / 8;
-        const bytes = this.parent.getBytes(this.offset, bc);
+        const bytes = this.tempValue;
         const buffer = Buffer.from(bytes);
         switch (bc) {
             case 1:


### PR DESCRIPTION
We noticed that when loading values from 8 bit registers on our MCU, the values were being displayed incorrectly, or in the wrong register. We believe this to be an endianess issue. The fix was to send commands to load each register individually instead of entire peripherals at a time. It is less efficient but it produces correct results. Debugging in eclipse had the same bug for us, so this was a big improvement. 

The other change was to wait for updateData() to finish before telling VSCode to update the peripheral tree. This fixes a refresh issue with the tree when updating values, where the values being displayed were not the latest values after changing one. 

Our changes are probably not super well integrated with the rest of the code because we are not super familiar with the code. I'm open to feedback and happy to improve or fix things to make it work better with the rest of the code. 