### PR TITLE
Add support for targetDownload option that can skip target-download GDB command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -900,6 +900,11 @@
                                 "maximum": 9,
                                 "default": 0
                             },
+                            "targetDownload": {
+                                "description": "If enabled the debugger will issue a target-download command when attaching GDB.",
+                                "type": "boolean",
+                                "default": true
+                            },
                             "graphConfig": {
                                 "items": {
                                     "oneOf": [

--- a/src/bmp.ts
+++ b/src/bmp.ts
@@ -59,11 +59,14 @@ export class BMPServerController extends EventEmitter implements GDBServerContro
     }
 
     public launchCommands(): string[] {
-        const commands = [
-            'target-download',
+        const commands = []
+        if (this.args.targetDownload)
+            commands.push('target-download');
+
+        commands.push(
             'interpreter-exec console "SoftwareReset"',
-            'enable-pretty-printing'
-        ];
+            'enable-pretty-printing');
+
         return commands;
     }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -106,6 +106,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     overrideGDBServerStartedRegex: string;
     svdFile: string;
     swoConfig: SWOConfiguration;
+    targetDownload: boolean;
     graphConfig: any[];
     showDevDebugOutput: boolean;
     showDevDebugTimestamps: boolean;

--- a/src/external.ts
+++ b/src/external.ts
@@ -35,12 +35,16 @@ export class ExternalServerController extends EventEmitter implements GDBServerC
 
     public launchCommands(): string[] {
         const commands = [
-            'interpreter-exec console "monitor reset halt"',
-            'target-download',
-            'interpreter-exec console "monitor reset halt"',
-            'enable-pretty-printing'
+            'interpreter-exec console "monitor halt"',
         ];
 
+        if (this.args.targetDownload) {
+            commands.push(
+                'target-download',
+                'interpreter-exec console "monitor reset"');
+        }
+
+        commands.push('enable-pretty-printing');
         return commands;
     }
 

--- a/src/jlink.ts
+++ b/src/jlink.ts
@@ -40,11 +40,16 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
     public launchCommands(): string[] {
         const commands = [
             'interpreter-exec console "monitor halt"',
-            'interpreter-exec console "monitor reset"',
-            'target-download',
-            'interpreter-exec console "monitor reset"',
-            'enable-pretty-printing'
+            'interpreter-exec console "monitor reset"'
         ];
+
+        if (this.args.targetDownload) {
+            commands.push(
+                'target-download',
+                'interpreter-exec console "monitor reset"');
+        }
+
+        commands.push('enable-pretty-printing');
         return commands;
     }
 

--- a/src/openocd.ts
+++ b/src/openocd.ts
@@ -40,11 +40,16 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
 
     public launchCommands(): string[] {
         const commands = [
-            'interpreter-exec console "monitor reset halt"',
-            'target-download',
-            'interpreter-exec console "monitor reset halt"',
-            'enable-pretty-printing'
+            'interpreter-exec console "monitor halt"',
         ];
+
+        if (this.args.targetDownload) {
+            commands.push(
+                'target-download',
+                'interpreter-exec console "monitor reset"');
+        }
+
+        commands.push('enable-pretty-printing');
         return commands;
     }
 

--- a/src/pemicro.ts
+++ b/src/pemicro.ts
@@ -39,11 +39,15 @@ export class PEServerController extends EventEmitter implements GDBServerControl
     public launchCommands(): string[] {
         const commands = [
             'interpreter-exec console "monitor _reset"',
-            'target-download',
-            'interpreter-exec console "monitor _reset"',
-            'enable-pretty-printing'
         ];
 
+        if (this.args.targetDownload) {
+            commands.push(
+                'target-download',
+                'interpreter-exec console "monitor _reset"');
+        }
+
+        commands.push('enable-pretty-printing');
         return commands;
     }
 

--- a/src/pyocd.ts
+++ b/src/pyocd.ts
@@ -36,11 +36,16 @@ export class PyOCDServerController extends EventEmitter implements GDBServerCont
 
     public launchCommands(): string[] {
         const commands = [
-            'interpreter-exec console "monitor reset halt"',
-            'target-download',
-            'interpreter-exec console "monitor reset halt"',
-            'enable-pretty-printing'
+            'interpreter-exec console "monitor halt"',
         ];
+
+        if (this.args.targetDownload) {
+            commands.push(
+                'target-download',
+                'interpreter-exec console "monitor reset"');
+        }
+
+        commands.push('enable-pretty-printing');
         return commands;
     }
 

--- a/src/stutil.ts
+++ b/src/stutil.ts
@@ -37,11 +37,16 @@ export class STUtilServerController extends EventEmitter implements GDBServerCon
     public launchCommands(): string[] {
         const commands = [
             'interpreter-exec console "monitor halt"',
-            'interpreter-exec console "monitor reset"',
-            'target-download',
-            'interpreter-exec console "monitor reset"',
-            'enable-pretty-printing'
-        ];
+            'interpreter-exec console "monitor reset"'
+        ]
+
+        if (this.args.targetDownload) {
+            commands.push(
+                'target-download',
+                'interpreter-exec console "monitor reset"');
+        }
+
+        commands.push('enable-pretty-printing');
         return commands;
     }
 


### PR DESCRIPTION
This can be useful if the debug target is already properly flashed, and prevents GDB from initiating a download procedure to the debug server.

Not skipping this can lead to the wrong binaries being flashed to a board.