### PR TITLE
Add support for remote target ip in GDB for WSL2 environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -655,6 +655,11 @@
                                 "pattern": "^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$",
                                 "type": "string"
                             },
+                            "remoteIPAddress": {
+                                "default": null,
+                                "description": "IP Address for remote target selection in gdb",
+                                "type": "string"
+                            },
                             "serialNumber": {
                                 "default": null,
                                 "description": "J-Link Serial Number - only needed if multiple J-Links are connected to the computer",
@@ -1225,6 +1230,11 @@
                                 "default": null,
                                 "description": "IP Address for networked J-Link Adapter",
                                 "pattern": "^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$",
+                                "type": "string"
+                            },
+                            "remoteIPAddress": {
+                                "default": null,
+                                "description": "IP Address for remote target selection in gdb",
                                 "type": "string"
                             },
                             "serialNumber": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -129,7 +129,8 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     ipAddress: string;
     serialNumber: string;
     jlinkscript: string;
-    
+    remoteIPAddress: string;
+
     // OpenOCD Specific
     configFiles: string[];
     searchDir: string[];
@@ -138,7 +139,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
 
     // PyOCD Specific
     boardId: string;
-    
+
     // StUtil Specific
     v1: boolean;
 

--- a/src/jlink.ts
+++ b/src/jlink.ts
@@ -28,12 +28,13 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
     public customRequest(command: string, response: DebugProtocol.Response, args: any): boolean {
         return false;
     }
-    
+
     public initCommands(): string[] {
         const gdbport = this.ports[createPortName(this.args.targetProcessor)];
+        const remoteip = (this.args.remoteIPAddress) ? this.args.remoteIPAddress : "localhost";
 
         return [
-            `target-select extended-remote localhost:${gdbport}`
+            `target-select extended-remote ${remoteip}:${gdbport}`
         ];
     }
 
@@ -77,7 +78,7 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
         const portMask = '0x' + calculatePortMask(this.args.swoConfig.decoders).toString(16);
         const swoFrequency = this.args.swoConfig.swoFrequency | 0;
         const cpuFrequency = this.args.swoConfig.cpuFrequency | 0;
-        
+
         const commands: string[] = [
             `monitor SWO EnableTarget ${cpuFrequency} ${swoFrequency} ${portMask} 0`,
             'DisableITMPorts 0xFFFFFFFF',
@@ -87,7 +88,7 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
         ];
 
         commands.push(this.args.swoConfig.profile ? 'EnablePCSample' : 'DisablePCSample');
-        
+
         return commands.map((c) => `interpreter-exec console "${c}"`);
     }
 
@@ -105,7 +106,7 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
             }
         }
     }
-    
+
     public serverArguments(): string[] {
         const gdbport = this.ports['gdbPort'];
         const swoport = this.ports['swoPort'];


### PR DESCRIPTION
The reasoning behind this, is using wsl2 in windows has no access
to the usb port, so one has to use jlinkgdbserver on the host, however
due to some changes in the WSL2, localhost no longer has access to the
host's listening ports, but instead the "default gateway" address
has to be used for connections. Though that is changing on reboot.

Without killing the gdb server between debug sessions, weird side effects
can occur (especially on exceptions) -> normally it gets stuck, and
restarting the gdbserver process is needed.

In this WSL2 scenario, one can use serverArgs -noLocalhostOnly to allow
remote access to the GDB server. And start the native windows executable
for JlinkGDBServerCL.exe in serverpath.

A better approach could be to introduce a wsl2 bool, which could
automatically get the default gw IP address and populate these two variables.