### PR TITLE
Make the SVDParser more robust

### DIFF
--- a/src/frontend/svd.ts
+++ b/src/frontend/svd.ts
@@ -110,6 +110,10 @@ export class SVDParser {
     private static parseFields(fieldInfo: any[], parent: PeripheralRegisterNode): PeripheralFieldNode[] {
         const fields: PeripheralFieldNode[] = [];
 
+        if (fieldInfo == null) {
+            return fields;
+        }
+
         fieldInfo.map((f) => {
             let offset;
             let width;


### PR DESCRIPTION
This commit adds a check to the parseFields() method. 

While the SVD schema requires all `<fields>...</fields>` tags to contain at minimum 1 `<field>...</field>` tag, some SVD files straight from the manufacturer/Keil do not follow this part of the spec. Previously, when encountering these poorly formed SVD files, the extension would fail with the message "undefined has no element map". With this commit, the extension simply ignores empty `<fields>...</fields>` tags.

This is particularly useful because this particular malformation of an SVD is not actually reported by Kiel's `SVDConv` tool, and the cortex-debug extension does not provide any sort of explanatory error message, so it isn't initially clear why it is rejecting the SVD file. When the SVD is 30k lines, manually identifying the error it isn't really a viable option. 

While cortex-debug isn't really under any obligation to support out-of-spec files like this, I'm sure the one I ran into isn't the only one floating around, and it's a really simple fix that might save someone a headache down the road.