### PR TITLE
RTT support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# V0.x.x (Unreleased)
+1. New features
+   * Support SEGGER RTT console output.
+
 # V0.3.7
 Minor bug fix release
 
@@ -74,7 +78,7 @@ This is a pretty big release. The biggest change is to address C++ (and maybe Ru
 	* `h` or `x` - format in hexadecimal
 	* `d` - format in decimal
 	* `o` - format in octal
-	
+
 	These format sepecifiers are appended to the end of the watch expression separated by a `,` - eg. `*(unsigned int *)(0x40011004),b` would display the contents at address `0x40011004` in binary.
 * Changed core registers to be displayed using their "natural" formatting:
 	* `rXX` in decimal

--- a/package.json
+++ b/package.json
@@ -464,6 +464,64 @@
                                 "description": "Path to an SVD file describing the peripherals of the microcontroller; if not supplied then one may be selected based upon the 'device' entered.",
                                 "type": "string"
                             },
+                            "rttConfig": {
+                                "properties": {
+                                    "enabled": {
+                                        "default": false,
+                                        "description": "Enable reading RTT output.",
+                                        "type": "boolean"
+                                    },
+                                    "host": {
+                                        "type": "string",
+                                        "default": "localhost",
+                                        "description": "The host name where the RTT server is running."
+                                    },
+                                    "decoders": {
+                                        "description": "RTT decoder configuration",
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "properties": {
+                                                        "label": {
+                                                            "description": "A label for the output window.",
+                                                            "type": "string"
+                                                        },
+                                                        "showOnStartup": {
+                                                            "description": "If true, switches to this output when starting a debug session.",
+                                                            "type": "boolean"
+                                                        },
+                                                        "channel": {
+                                                            "description": "RTT Channel Number",
+                                                            "minimum": 0,
+                                                            "type": "number"
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "console"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "encoding": {
+                                                            "type": "string",
+                                                            "default": "utf8",
+                                                            "enum": [
+                                                                "ascii",
+                                                                "utf8",
+                                                                "ucs2",
+                                                                "utf16le"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [],
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "required": [],
+                                "type": "object"
+                            },
                             "swoConfig": {
                                 "properties": {
                                     "cpuFrequency": {
@@ -1536,7 +1594,7 @@
     "devDependencies": {
         "@types/binary-parser": "^1.3.1",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.14.9",
+        "@types/node": "^10.17.32",
         "mocha": "^5.2.0",
         "ts-loader": "^6.0.3",
         "tslint": "^5.17.0",

--- a/src/common.ts
+++ b/src/common.ts
@@ -45,6 +45,19 @@ export class StoppedEvent extends Event implements DebugProtocol.Event {
     }
 }
 
+export class RTTConfigureEvent extends Event implements DebugProtocol.Event {
+    public body: {
+        type: string,
+        host: string
+    };
+    public event: string;
+
+    constructor(params: any) {
+        const body = params;
+        super('rtt-configure', body);
+    }
+}
+
 export class SWOConfigureEvent extends Event implements DebugProtocol.Event {
     public body: {
         type: string,
@@ -83,6 +96,12 @@ export interface SWOConfiguration {
     source: string;
 }
 
+export interface RTTConfiguration {
+    enabled: boolean;
+    host: string;
+    decoders: any[];
+}
+
 export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArguments {
     toolchainPath: string;
     toolchainPrefix: string;
@@ -106,6 +125,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     overrideGDBServerStartedRegex: string;
     svdFile: string;
     swoConfig: SWOConfiguration;
+    rttConfig: RTTConfiguration;
     graphConfig: any[];
     showDevDebugOutput: boolean;
     showDevDebugTimestamps: boolean;
@@ -129,7 +149,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     ipAddress: string;
     serialNumber: string;
     jlinkscript: string;
-    
+
     // OpenOCD Specific
     configFiles: string[];
     searchDir: string[];
@@ -138,7 +158,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
 
     // PyOCD Specific
     boardId: string;
-    
+
     // StUtil Specific
     v1: boolean;
 
@@ -150,7 +170,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     cpu: string;
     machine: string;
 
-    // External 
+    // External
     gdbTarget: string;
 
     // Hidden settings - These settings are for advanced configuration and are not exposed in the package.json file

--- a/src/frontend/rtt/common.ts
+++ b/src/frontend/rtt/common.ts
@@ -1,0 +1,14 @@
+export interface RTTDecoderConfig {
+    type: string;
+}
+
+export interface RTTBasicDecoderConfig extends RTTDecoderConfig {
+    channel: number;
+}
+
+export interface RTTConsoleDecoderConfig extends RTTBasicDecoderConfig {
+    label: string;
+    encoding: string;
+    showOnStartup: boolean;
+    timestamp: boolean;
+}

--- a/src/frontend/rtt/core.ts
+++ b/src/frontend/rtt/core.ts
@@ -1,0 +1,71 @@
+import * as vscode from 'vscode';
+
+import { RTTConsoleProcessor } from './decoders/console';
+import { RTTDecoder } from './decoders/common';
+import { RTTDecoderConfig, RTTConsoleDecoderConfig } from './common';
+import { SocketRTTSource } from './sources/socket';
+import { SymbolInformation } from '../../symbols';
+
+interface ConfigurationArguments {
+    executable: string;
+    rttConfig: {
+        enabled: boolean,
+        host: string,
+        decoders: RTTDecoderConfig[]
+    };
+}
+
+export class RTTCore {
+    private processors: RTTDecoder[] = [];
+    private functionSymbols: SymbolInformation[];
+
+    constructor(args: ConfigurationArguments, extensionPath: string) {
+        vscode.debug.activeDebugSession.customRequest('load-function-symbols').then((result) => {
+            this.functionSymbols = result.functionSymbols;
+        }, (error) => {
+            this.functionSymbols = [];
+        });
+
+        args.rttConfig.decoders.forEach((conf) => {
+            switch (conf.type) {
+                case 'console':
+                    const decoderConfig = conf as RTTConsoleDecoderConfig;
+                    this.processors.push(
+                        new RTTConsoleProcessor(
+                            new SocketRTTSource(args.rttConfig.host, decoderConfig.channel),
+                            decoderConfig
+                        )
+                    );
+                    break;
+
+                default:
+                    console.log('Unknown RTT decoder: ', conf.type);
+                    break;
+            }
+        });
+    }
+
+    public debugSessionTerminated() {
+
+    }
+
+    public debugStopped() {
+
+    }
+
+    public debugContinued() {
+
+    }
+
+    public dispose() {
+        this.processors.forEach((p) => p.dispose());
+        this.processors = null;
+    }
+
+    public getFunctionAtAddress(address: number): SymbolInformation {
+        const matches = this.functionSymbols.filter((s) => s.address <= address && (s.address + s.length) > address);
+        if (!matches || matches.length === 0) { return undefined; }
+
+        return matches[0];
+    }
+}

--- a/src/frontend/rtt/core.ts
+++ b/src/frontend/rtt/core.ts
@@ -4,7 +4,6 @@ import { RTTConsoleProcessor } from './decoders/console';
 import { RTTDecoder } from './decoders/common';
 import { RTTDecoderConfig, RTTConsoleDecoderConfig } from './common';
 import { SocketRTTSource } from './sources/socket';
-import { SymbolInformation } from '../../symbols';
 
 interface ConfigurationArguments {
     executable: string;
@@ -17,15 +16,8 @@ interface ConfigurationArguments {
 
 export class RTTCore {
     private processors: RTTDecoder[] = [];
-    private functionSymbols: SymbolInformation[];
 
     constructor(args: ConfigurationArguments, extensionPath: string) {
-        vscode.debug.activeDebugSession.customRequest('load-function-symbols').then((result) => {
-            this.functionSymbols = result.functionSymbols;
-        }, (error) => {
-            this.functionSymbols = [];
-        });
-
         args.rttConfig.decoders.forEach((conf) => {
             switch (conf.type) {
                 case 'console':
@@ -60,12 +52,5 @@ export class RTTCore {
     public dispose() {
         this.processors.forEach((p) => p.dispose());
         this.processors = null;
-    }
-
-    public getFunctionAtAddress(address: number): SymbolInformation {
-        const matches = this.functionSymbols.filter((s) => s.address <= address && (s.address + s.length) > address);
-        if (!matches || matches.length === 0) { return undefined; }
-
-        return matches[0];
     }
 }

--- a/src/frontend/rtt/decoders/common.ts
+++ b/src/frontend/rtt/decoders/common.ts
@@ -1,0 +1,6 @@
+export interface RTTDecoder {
+    format: string;
+
+    data(buffer: Buffer);
+    dispose();
+}

--- a/src/frontend/rtt/decoders/console.ts
+++ b/src/frontend/rtt/decoders/console.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+
+import { RTTDecoder } from './common';
+import { RTTConsoleDecoderConfig } from '../common';
+import { RTTSource } from '../sources/common';
+
+export class RTTConsoleProcessor implements RTTDecoder {
+    private output: vscode.OutputChannel;
+    private position: number = 0;
+    public readonly format: string = 'console';
+    private encoding: string;
+
+    constructor(private source: RTTSource, private config: RTTConsoleDecoderConfig) {
+        this.encoding = config.encoding || 'utf8';
+
+        this.source.on('data', this.data.bind(this));
+        if (this.source.connected) {
+            this.createOutputChannel();
+        } else {
+            this.source.on('connected', this.createOutputChannel.bind(this));
+        }
+    }
+
+    private createOutputChannel() {
+        this.output = vscode.window.createOutputChannel(`RTT: ${this.config.label || ''} [channel: ${this.config.channel}, type: console]`);
+        if (this.config.showOnStartup) {
+            this.output.show(true);
+        }
+    }
+
+    public data(packet: Buffer) {
+        const letters = packet.toString(this.encoding);
+
+        for (const letter of letters) {
+            if (letter === '\n') {
+                this.output.append('\n');
+                this.position = 0;
+                continue;
+            }
+
+            if (this.position === 0 && this.config.timestamp) {
+                const date = new Date();
+                const header = `[${date.toISOString()}]   `;
+                this.output.append(header);
+            }
+
+            this.output.append(letter);
+            this.position += 1;
+
+            if (this.position >= 80) {
+                this.output.append('\n');
+                this.position = 0;
+            }
+        }
+    }
+
+    public dispose() {
+        this.source.dispose();
+        this.output.dispose();
+    }
+}

--- a/src/frontend/rtt/sources/common.ts
+++ b/src/frontend/rtt/sources/common.ts
@@ -1,0 +1,6 @@
+import { EventEmitter } from 'events';
+
+export interface RTTSource extends EventEmitter {
+    connected: boolean;
+    dispose();
+}

--- a/src/frontend/rtt/sources/socket.ts
+++ b/src/frontend/rtt/sources/socket.ts
@@ -1,0 +1,23 @@
+import { RTTSource } from './common';
+import { EventEmitter } from 'events';
+import * as net from 'net';
+
+export class SocketRTTSource extends EventEmitter implements RTTSource {
+    private client: net.Socket = null;
+    public connected: boolean = false;
+
+    constructor(private RTTHost: string, private RTTChannel: number) {
+        super();
+        this.client = net.createConnection({ port: 19021, host: this.RTTHost }, () => {
+            this.client.write(`$$SEGGER_TELNET_ConfigStr=RTTCh;${this.RTTChannel};$$`);
+            this.connected = true;
+            this.emit('connected');
+        });
+        this.client.on('data', (buffer) => { this.emit('data', buffer); });
+        this.client.on('end', () => { this.emit('disconnected'); });
+    }
+
+    public dispose() {
+        this.client.destroy();
+    }
+}

--- a/src/jlink.ts
+++ b/src/jlink.ts
@@ -1,5 +1,5 @@
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { GDBServerController, ConfigurationArguments, calculatePortMask, createPortName,SWOConfigureEvent } from './common';
+import { GDBServerController, ConfigurationArguments, calculatePortMask, createPortName, SWOConfigureEvent, RTTConfigureEvent } from './common';
 import * as os from 'os';
 import { EventEmitter } from 'events';
 
@@ -28,7 +28,7 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
     public customRequest(command: string, response: DebugProtocol.Response, args: any): boolean {
         return false;
     }
-    
+
     public initCommands(): string[] {
         const gdbport = this.ports[createPortName(this.args.targetProcessor)];
 
@@ -77,7 +77,7 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
         const portMask = '0x' + calculatePortMask(this.args.swoConfig.decoders).toString(16);
         const swoFrequency = this.args.swoConfig.swoFrequency | 0;
         const cpuFrequency = this.args.swoConfig.cpuFrequency | 0;
-        
+
         const commands: string[] = [
             `monitor SWO EnableTarget ${cpuFrequency} ${swoFrequency} ${portMask} 0`,
             'DisableITMPorts 0xFFFFFFFF',
@@ -87,7 +87,7 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
         ];
 
         commands.push(this.args.swoConfig.profile ? 'EnablePCSample' : 'DisablePCSample');
-        
+
         return commands.map((c) => `interpreter-exec console "${c}"`);
     }
 
@@ -105,7 +105,7 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
             }
         }
     }
-    
+
     public serverArguments(): string[] {
         const gdbport = this.ports['gdbPort'];
         const swoport = this.ports['swoPort'];
@@ -145,7 +145,7 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
         return /Waiting for GDB connection\.\.\./g;
     }
 
-    public serverLaunchStarted(): void {}
+    public serverLaunchStarted(): void { }
     public serverLaunchCompleted(): void {
         if (this.args.swoConfig.enabled) {
             if (this.args.swoConfig.source === 'probe') {
@@ -160,7 +160,10 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
                 }));
             }
         }
+        if (this.args.rttConfig.enabled) {
+            this.emit('event', new RTTConfigureEvent({ type: 'socket', host: this.args.rttConfig.host }));
+        }
     }
-    public debuggerLaunchStarted(): void {}
-    public debuggerLaunchCompleted(): void {}
+    public debuggerLaunchStarted(): void { }
+    public debuggerLaunchCompleted(): void { }
 }


### PR DESCRIPTION
Implementation is based on SWO. Currently output is read from the telnet server and I think this makes it a bit slower than ideal.

I think a lot of this could be refactored together with SWO under a common IO implementation, but there are some differences and I didn't want to mess anything up in the process.

A screenshot of the feature working:
![image](https://user-images.githubusercontent.com/977627/93100699-c1d3a380-f6a9-11ea-8e23-2e32d482b01d.png)

Limitations:
 - I think it's not possible to select two channels at once

Differences with SWO:
- Only console decoder is implemented, but graphing and advanced can be introduced later or even in this PR. Advanced decoding can only work with one channel unfortunately, I think it's hopeless to sync multiple socket connections.
- There's a `timestamp` configuration that's off by default - this can be changed to on by default and also ported over to SWO easily enough.