### PR TITLE
Initial proof of concept for FreeRTOS task information

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Requirements:
 
 See https://github.com/Marus/cortex-debug/wiki for usage information. This needs some help from the community
 
+## Development
+
+Clone the Git repository, open the folder in VSCode and open a terminal. Run
+$ npm install
+$ npm run-script compile
+Now hit F5 to open a new VSCode window with the development extension running, you can load an existing project and launch the debugger for testing.
+
 ## Acknowledgments
 
 Parts of this extension are based upon Jan Jurzitza's (WebFreak) code-debug extension (https://github.com/WebFreak001/code-debug). His project provided an excellent base for GDB MI parsing and interaction.

--- a/package.json
+++ b/package.json
@@ -1505,6 +1505,11 @@
                     "id": "cortex-debug.registers",
                     "name": "Cortex Registers",
                     "when": "debugType == cortex-debug"
+                },
+                {
+                    "id": "cortex-debug.freertos",
+                    "name": "FreeRTOS Tasks",
+                    "when": "debugType == cortex-debug"
                 }
             ]
         }

--- a/src/frontend/views/freertos.ts
+++ b/src/frontend/views/freertos.ts
@@ -1,0 +1,104 @@
+import { TreeItem, TreeDataProvider, EventEmitter, Event, TreeItemCollapsibleState, debug, workspace, ProviderResult} from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { NodeSetting } from '../../common';
+import reporting from '../../reporting';
+import { BaseNode } from './nodes/basenode';
+import { MessageNode } from './nodes/messagenode';
+import { FreertosTask, FreertosTaskNode } from './nodes/freertostasknode';
+import { FreeRTOSTaskFieldNode } from './nodes/freertostaskfieldnode';
+
+export class FreeRTOSTreeProvider implements TreeDataProvider<BaseNode> {
+    // tslint:disable-next-line:variable-name
+    public _onDidChangeTreeData: EventEmitter<BaseNode | undefined> = new EventEmitter<BaseNode | undefined>();
+    public readonly onDidChangeTreeData: Event<BaseNode | undefined> = this._onDidChangeTreeData.event;
+
+    private loaded: boolean = false;
+    private taskNodes: FreertosTaskNode[];
+
+    constructor() {
+        this.taskNodes = [];
+    }
+
+    public refresh(): void {
+        if (debug.activeDebugSession) {
+            debug.activeDebugSession.customRequest('read-freertos').then((data) => {
+
+                // we will get some data back for every task (just address and state if nothing else has changed)
+                // we can remove any task that is not in the return data
+
+                for (const taskData of data.tasks) {
+                    const taskNode = this.taskNodes.findIndex((taskNode) => taskNode.task.address === taskData.address);
+                    if (taskNode > -1) {
+                        this.taskNodes[taskNode].task = {...this.taskNodes[taskNode].task, ...taskData};
+                    }
+                    else {
+                        const task: FreertosTask = {
+                            name: taskData.name ? taskData.name : `@${taskData.address}`,
+                            priority: taskData.priority,
+                            stackTop: taskData.stackTop,
+                            stackStart: taskData.stackStart,
+                            stackEnd: taskData.stackEnd ? taskData.stackEnd : 'unknown',
+                            state: taskData.state,
+                            address: taskData.address
+                        };
+
+                        const node = new FreertosTaskNode(task);
+                        this.taskNodes.push(node);
+                    }
+                }
+            });
+
+            this._onDidChangeTreeData.fire();
+        }
+    }
+
+    public _refreshRegisterValues() {
+    }
+
+    public getTreeItem(element: BaseNode): TreeItem | Promise<TreeItem> {
+        return element.getTreeItem();
+    }
+
+    public createRegisters(regInfo: string[]) {
+
+    }
+
+    public getChildren(element?: BaseNode): ProviderResult<BaseNode[]> {
+        if (!this.loaded) {
+            return [new MessageNode('Not in active debug session.')];
+        }
+        else if (this.taskNodes.length === 0) {
+            return [new MessageNode('No tasks found.')];
+        }
+        else if (this.taskNodes.length > 0) {
+            return element ? element.getChildren() : this.taskNodes;
+        }
+        else {
+            return [];
+        }
+    }
+
+    public _saveState(fspath: string) {
+    }
+
+    public debugSessionTerminated() {
+        this.loaded = false;
+        this._onDidChangeTreeData.fire();
+    }
+
+    public debugSessionStarted() {
+        this.loaded = true;
+        this._onDidChangeTreeData.fire();
+    }
+
+    public debugStopped() {
+        this.refresh();
+        this._onDidChangeTreeData.fire();
+    }
+
+    public debugContinued() {
+
+    }
+}

--- a/src/frontend/views/nodes/freertostaskfieldnode.ts
+++ b/src/frontend/views/nodes/freertostaskfieldnode.ts
@@ -1,0 +1,28 @@
+import { BaseNode } from './basenode';
+import { TreeItem, TreeItemCollapsibleState } from 'vscode';
+import { FreertosTaskNode } from './freertostasknode';
+
+export class FreeRTOSTaskFieldNode extends BaseNode {
+    constructor(public name: string, private property, private taskNode: FreertosTaskNode) {
+        super(taskNode);
+    }
+
+    public getChildren(): BaseNode[] | Promise<BaseNode[]> {
+        return [];
+    }
+
+    public getTreeItem(): TreeItem | Promise<TreeItem> {
+        const ti = new TreeItem(this.name, TreeItemCollapsibleState.None);
+        const value = this.taskNode.task[this.property];
+
+        ti.description = value.toString();
+        ti.contextValue = 'field';
+
+        return ti;
+    }
+
+    public getCopyValue(): string | undefined {
+        const value = this.taskNode.task[this.property];
+        return value.toString();
+    }
+}

--- a/src/frontend/views/nodes/freertostasknode.ts
+++ b/src/frontend/views/nodes/freertostasknode.ts
@@ -1,0 +1,65 @@
+import { TreeItem, TreeItemCollapsibleState } from 'vscode';
+
+import { BaseNode } from './basenode';
+import { NodeSetting } from '../../../common';
+
+import { hexFormat, binaryFormat, createMask, extractBits } from '../../utils';
+import { FreeRTOSTaskFieldNode } from './freertostaskfieldnode';
+
+export interface FreertosTask {
+    name: string;
+    address: number;
+    priority: number;
+    stackTop: number;
+    stackStart: number;
+    stackEnd: number;
+    state: string;
+}
+
+export class FreertosTaskNode extends BaseNode {
+
+    private fields: FreeRTOSTaskFieldNode[];
+
+    constructor(public task: FreertosTask) {
+        super(null);
+
+        this.fields = [
+            new FreeRTOSTaskFieldNode('name', 'name', this),
+            new FreeRTOSTaskFieldNode('address', 'address', this),
+            new FreeRTOSTaskFieldNode('stack top', 'stackTop', this),
+            new FreeRTOSTaskFieldNode('priority', 'priority', this),
+            new FreeRTOSTaskFieldNode('state', 'state', this)
+        ];
+    }
+
+    public getTreeItem(): TreeItem | Promise<TreeItem> {
+        const state = this.fields && this.fields.length > 0 ?
+            (this.expanded ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.Collapsed)
+            : TreeItemCollapsibleState.None;
+
+        const item = new TreeItem(this.task.name, state);
+        item.description = this.task.state;
+        item.contextValue = 'register';
+
+        return item;
+    }
+
+    public getChildren(): FreeRTOSTaskFieldNode[] {
+        return this.fields;
+    }
+
+    public getAddress(): number {
+        return this.task.address;
+    }
+
+    public getCopyValue(): string {
+        // TODO: copy out whole interface
+        return '';
+    }
+
+    public _saveState(): NodeSetting[] {
+        const settings: NodeSetting[] = [];
+
+        return settings;
+    }
+}


### PR DESCRIPTION
This is a first attempt at putting FreeRTOS aware debugging into the cortex-debug extension. I have never controlled gdb directly or written / modified a VSCode extension before, so I may have made some fundamental errors. I am hoping that the community that uses this extension is interested in these features and that we can shape what I have started into something useful for everyone.

First thing I need to work out is how to only turn on the FreeRTOS view if the rtos = 'FreeRTOS' option is set. At the moment I can't see how this is done as the view is set in package.json. Is there some way to hide / disable it?

I would also like to extend the functionality to include stack free space as this is invaluable. Performance data can also be included with the right config.

I am not expecting this to be merged as is, but I was hoping I can get some direction from the maintainers as to where this needs to go to be accepted.