### PR TITLE
Toggle disabling and enabling FunctionBreakPoints.

### DIFF
--- a/src/frontend/svd.ts
+++ b/src/frontend/svd.ts
@@ -110,6 +110,10 @@ export class SVDParser {
     private static parseFields(fieldInfo: any[], parent: PeripheralRegisterNode): PeripheralFieldNode[] {
         const fields: PeripheralFieldNode[] = [];
 
+        if (fieldInfo == null) {
+            return fields;
+        }
+
         fieldInfo.map((f) => {
             let offset;
             let width;


### PR DESCRIPTION
Currently, FunctionBreakPoints cannot be disabled even if the check box is cleared.
This fix toggles between disabling and enabling FunctionBreakPoints with checkbox.