### PR TITLE
delete all break points with disconnect.

### DIFF
--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -773,6 +773,7 @@ export class GDBDebugSession extends DebugSession {
 
     protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void {
         const doDisconnectProcessing = () => {
+            this.miDebugger.sendCommand('break-delete');
             if (this.attached) {
                 this.attached = false;
                 this.miDebugger.detach();


### PR DESCRIPTION
Some targets still alive break-points even if disconnected.
When hits the break-points without a debugger, there is no way to continue with the target still stopped.