### PR TITLE
Added initial support for STMicroelectronic's ST-LINK gdbserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Requirements:
     * OpenOCD - provides a GDB Server that can be used with a number of debuggers (http://openocd.org)
         * NOTE: On macOS do not use the default version of OpenOCD provided by homebrew, this is not compatible with releases V0.2.4 and newer. You can either install from source using homebrew (`brew install open-ocd --HEAD`) or the packages from https://github.com/gnu-mcu-eclipse/openocd/releases will also work. Some linux versions and Windows may also need a more up-to-date version of OpenOCD from the gnu-mcu-eclipse releases.
     * Texane's st-util GDB server - Only supports ST-Link Debug Probes (https://github.com/texane/stlink)
-    * ST-LINK GDB server - This server is packaged with the [STM32CubeIDE](https://www.st.com/en/development-tools/stm32cubeide.html). In addition the [STM32CubeProgrammer](https://www.st.com/en/development-tools/stm32cubeprog.html) tool must be installed.
+    * ST-LINK GDB server - This server is packaged with the [STM32CubeIDE](https://www.st.com/en/development-tools/stm32cubeide.html) which must be installed. The location of the STM32CubeIDE and related tools is automatically resolved but also can be overridden using configuration settings (`armToolchainPath`, `stm32cubeprogrammer` and `serverpath`).
     * pyOCD GDB Server - GDB server that supports the CMSIS-DAP debugger on a number of mbed boards (https://github.com/mbedmicro/pyOCD)
     * Black Magic Probe
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Debugging support for ARM Cortex-M Microcontrollers with the following features:
 
 * Support J-Link, OpenOCD GDB Server
+* Initial support for STMicroelectronic's ST-LINK GDB server (no SWO support yet)
 * Partial support for PyOCD and textane/stlink (st-util) GDB Servers (SWO can only be captured via a serial port)
 * Initial support for the Black Magic Probe (This has not been as heavily tested; SWO can only be captured via a serial port)
 * Cortex Core Register Viewer
@@ -44,6 +45,7 @@ Requirements:
     * OpenOCD - provides a GDB Server that can be used with a number of debuggers (http://openocd.org)
         * NOTE: On macOS do not use the default version of OpenOCD provided by homebrew, this is not compatible with releases V0.2.4 and newer. You can either install from source using homebrew (`brew install open-ocd --HEAD`) or the packages from https://github.com/gnu-mcu-eclipse/openocd/releases will also work. Some linux versions and Windows may also need a more up-to-date version of OpenOCD from the gnu-mcu-eclipse releases.
     * Texane's st-util GDB server - Only supports ST-Link Debug Probes (https://github.com/texane/stlink)
+    * ST-LINK GDB server - This server is packaged with the [STM32CubeIDE](https://www.st.com/en/development-tools/stm32cubeide.html). In addition the [STM32CubeProgrammer](https://www.st.com/en/development-tools/stm32cubeprog.html) tool must be installed.
     * pyOCD GDB Server - GDB server that supports the CMSIS-DAP debugger on a number of mbed boards (https://github.com/mbedmicro/pyOCD)
     * Black Magic Probe
 

--- a/package.json
+++ b/package.json
@@ -1294,7 +1294,7 @@
                             },
                             "stm32cubeprogrammer": {
                                 "default": null,
-                                "description": "Path to the STM32CubeProgrammer tool's bin directory. Either installed as part os STM32CubeIDE or separatly.",
+                                "description": "This path is normally resolved to the installed STM32CubeIDE or STM32CubeProgrammer but can be overridden here.",
                                 "type": "string"
                             },
                             "targetId": {
@@ -1375,10 +1375,7 @@
                             "name": "${6:Debug Microcontroller}",
                             "request": "launch",
                             "type": "cortex-debug",
-                            "servertype": "stlink",
-                            "armToolchainPath": "c:/ST/STM32CubeIDE_1.5.0/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.7-2018-q2-update.win32_1.5.0.202011040924/tools/bin",
-                            "stm32cubeprogrammer": "c:/ST/STM32CubeIDE_1.5.0/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.cubeprogrammer.win32_1.5.0.202011040924/tools/bin",
-                            "serverpath": "c:/ST/STM32CubeIDE_1.5.0/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.stlink-gdb-server.win32_1.5.0.202011040924/tools/bin/ST-LINK_gdbserver.exe"
+                            "servertype": "stlink"
                         },
                         "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + STMicroelectronic's ST-LINK_gdbserver part of STM32CubeIDE",
                         "label": "Cortex Debug: ST-LINK"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,14 @@
                     "default": null,
                     "description": "Path to the Texane's ST-Util GDB Server executable. If not set then st-util (st-util.exe on Windows) must be on the system path."
                 },
+                "cortex-debug.stlinkPath": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "description": "Path to the ST-LINK_gdbserver executable. If not set then ST-LINK_gdbserver (ST-LINK_gdbserver.exe on Windows) must be on the system path."
+                },
                 "cortex-debug.enableTelemetry": {
                     "type": "boolean",
                     "default": true,
@@ -171,12 +179,13 @@
                         "properties": {
                             "servertype": {
                                 "type": "string",
-                                "description": "GDB Server type - supported types are jlink, openocd, pyocd, pe and stutil",
+                                "description": "GDB Server type - supported types are jlink, openocd, pyocd, pe, stlink, stutil, qemu and external",
                                 "enum": [
                                     "jlink",
                                     "openocd",
                                     "pyocd",
                                     "stutil",
+                                    "stlink",
                                     "bmp",
                                     "pe",
                                     "qemu",
@@ -657,12 +666,12 @@
                             },
                             "serialNumber": {
                                 "default": null,
-                                "description": "J-Link Serial Number - only needed if multiple J-Links are connected to the computer",
+                                "description": "J-Link or ST-LINK Serial Number - only needed if multiple J-Links/ST-LINKs are connected to the computer",
                                 "type": "string"
                             },
                             "interface": {
                                 "default": "swd",
-                                "description": "Debug Interface type to use for connections (defaults to SWD) - Used for J-Link and BMP probes.",
+                                "description": "Debug Interface type to use for connections (defaults to SWD) - Used for J-Link, ST-LINK and BMP probes.",
                                 "type": "string",
                                 "enum": [
                                     "swd",
@@ -742,12 +751,13 @@
                         "properties": {
                             "servertype": {
                                 "type": "string",
-                                "description": "GDB Server type - supported types are jlink, openocd, pyocd, pe and stutil",
+                                "description": "GDB Server type - supported types are jlink, openocd, pyocd, pe, stlink, stutil, qemu and external",
                                 "enum": [
                                     "jlink",
                                     "openocd",
                                     "pyocd",
                                     "stutil",
+                                    "stlink",
                                     "bmp",
                                     "pe",
                                     "qemu",
@@ -1229,12 +1239,12 @@
                             },
                             "serialNumber": {
                                 "default": null,
-                                "description": "J-Link Serial Number - only needed if multiple J-Links are connected to the computer",
+                                "description": "J-Link or ST-LINK Serial Number - only needed if multiple J-Links/ST-LINKs are connected to the computer",
                                 "type": "string"
                             },
                             "interface": {
                                 "default": "swd",
-                                "description": "Debug Interface type to use for connections (defaults to SWD) - Used for J-Link and BMP probes.",
+                                "description": "Debug Interface type to use for connections (defaults to SWD) - Used for J-Link, ST-LINK and BMP probes.",
                                 "type": "string",
                                 "enum": [
                                     "swd",
@@ -1279,8 +1289,13 @@
                             },
                             "v1": {
                                 "default": false,
-                                "description": "Set this to true if your debug probe is a ST-Link V1 (for example, the ST-Link on the STM32 VL Discovery is a V1 device). When set to false a ST-Link V2 device is used.",
+                                "description": "For st-util only. Set this to true if your debug probe is a ST-Link V1 (for example, the ST-Link on the STM32 VL Discovery is a V1 device). When set to false a ST-Link V2 device is used.",
                                 "type": "boolean"
+                            },
+                            "stm32cubeprogrammer": {
+                                "default": null,
+                                "description": "Path to the STM32CubeProgrammer tool's bin directory. Either installed as part os STM32CubeIDE or separatly.",
+                                "type": "string"
                             },
                             "targetId": {
                                 "description": "On BMP this is the ID number that should be passed to the attach command (defaults to 1); for PyOCD this is the target identifier (only needed for custom hardware)",
@@ -1352,6 +1367,21 @@
                         },
                         "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + Texane's st-util GDB server (https://github.com/texane/stlink)",
                         "label": "Cortex Debug: ST-Util"
+                    },
+                    {
+                        "body": {
+                            "cwd": "^\"\\${workspaceRoot}\"",
+                            "executable": "${1:./bin/executable.elf}",
+                            "name": "${6:Debug Microcontroller}",
+                            "request": "launch",
+                            "type": "cortex-debug",
+                            "servertype": "stlink",
+                            "armToolchainPath": "c:/ST/STM32CubeIDE_1.5.0/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.7-2018-q2-update.win32_1.5.0.202011040924/tools/bin",
+                            "stm32cubeprogrammer": "c:/ST/STM32CubeIDE_1.5.0/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.cubeprogrammer.win32_1.5.0.202011040924/tools/bin",
+                            "serverpath": "c:/ST/STM32CubeIDE_1.5.0/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.stlink-gdb-server.win32_1.5.0.202011040924/tools/bin/ST-LINK_gdbserver.exe"
+                        },
+                        "description": "Debugs an embedded ARM Cortex-M microcontroller using GDB + STMicroelectronic's ST-LINK_gdbserver part of STM32CubeIDE",
+                        "label": "Cortex Debug: ST-LINK"
                     },
                     {
                         "body": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -142,6 +142,9 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     // StUtil Specific
     v1: boolean;
 
+    // ST-LINK GDB server specific
+    stm32cubeprogrammer: string;
+
     // BMP Specific
     BMPGDBSerialPort: string;
     powerOverBMP: string;

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -70,6 +70,9 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
             case 'stutil':
                 validationResponse = this.verifySTUtilConfiguration(folder, config);
                 break;
+            case 'stlink':
+                validationResponse = this.verifySTLinkConfiguration(folder, config);
+                break;
             case 'pyocd':
                 validationResponse = this.verifyPyOCDConfiguration(folder, config);
                 break;
@@ -87,7 +90,7 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
                 break;
             default:
                 // tslint:disable-next-line:max-line-length
-                validationResponse = 'Invalid servertype parameters. The following values are supported: "jlink", "openocd", "stutil", "pyocd", "bmp", "pe", "qemu", "external"';
+                validationResponse = 'Invalid servertype parameters. The following values are supported: "jlink", "openocd", "stlink", "stutil", "pyocd", "bmp", "pe", "qemu", "external"';
                 break;
         }
 
@@ -203,6 +206,26 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
 
         if (config.swoConfig.enabled && config.swoConfig.source === 'probe') {
             vscode.window.showWarningMessage('SWO support is not available from the probe when using the ST-Util GDB server. Disabling SWO.');
+            config.swoConfig = { enabled: false, ports: [], cpuFrequency: 0, swoFrequency: 0 };
+            config.graphConfig = [];
+        }
+
+        return null;
+    }
+
+    private verifySTLinkConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration): string {
+        if (config.stlinkpath && !config.serverpath) { config.serverpath = config.stlinkpath; }
+        if (!config.serverpath) {
+            const configuration = vscode.workspace.getConfiguration('cortex-debug');
+            config.serverpath = configuration.stlinkpath;
+        }
+
+        if (config.rtos) {
+            return 'The ST-Link GDB Server does not have support for the rtos option.';
+        }
+
+        if (config.swoConfig.enabled && config.swoConfig.source === 'probe') {
+            vscode.window.showWarningMessage('SWO support is not available from the probe when using the ST-Link GDB server. Disabling SWO.');
             config.swoConfig = { enabled: false, ports: [], cpuFrequency: 0, swoFrequency: 0 };
             config.graphConfig = [];
         }

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as os from 'os';
+import { STLinkServerController } from './../stlink';
 
 const OPENOCD_VALID_RTOS: string[] = ['eCos', 'ThreadX', 'FreeRTOS', 'ChibiOS', 'embKernel', 'mqx', 'uCOS-III', 'auto'];
 const JLINK_VALID_RTOS: string[] = ['FreeRTOS', 'embOS'];
@@ -95,6 +96,12 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
         }
 
         const configuration = vscode.workspace.getConfiguration('cortex-debug');
+
+        // Special case to auto-resolve GCC toolchain for STM32CubeIDE users
+        if (!config.armToolchainPath && config.servertype === 'stlink') {
+           config.armToolchainPath = STLinkServerController.getArmToolchainPath();
+        }
+
         if (config.armToolchainPath) { config.toolchainPath = config.armToolchainPath; }
         if (!config.toolchainPath) {
             config.toolchainPath = configuration.armToolchainPath;

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -20,6 +20,7 @@ import { EventEmitter } from 'events';
 import { JLinkServerController } from './jlink';
 import { OpenOCDServerController } from './openocd';
 import { STUtilServerController } from './stutil';
+import { STLinkServerController } from './stlink';
 import { PyOCDServerController } from './pyocd';
 import { BMPServerController } from './bmp';
 import { PEServerController } from './pemicro';
@@ -33,6 +34,7 @@ const SERVER_TYPE_MAP = {
     jlink: JLinkServerController,
     openocd: OpenOCDServerController,
     stutil: STUtilServerController,
+    stlink: STLinkServerController,
     pyocd: PyOCDServerController,
     pe: PEServerController,
     bmp: BMPServerController,

--- a/src/stlink.ts
+++ b/src/stlink.ts
@@ -1,0 +1,149 @@
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { GDBServerController, ConfigurationArguments, SWOConfigureEvent, calculatePortMask, createPortName } from './common';
+import * as os from 'os';
+import { EventEmitter } from 'events';
+
+export class STLinkServerController extends EventEmitter implements GDBServerController {
+    public readonly name: string = 'ST-LINK';
+    public readonly portsNeeded: string[] = ['gdbPort'];
+
+    private args: ConfigurationArguments;
+    private ports: { [name: string]: number };
+
+    constructor() {
+        super();
+    }
+
+    public setPorts(ports: { [name: string]: number }): void {
+        this.ports = ports;
+    }
+
+    public setArguments(args: ConfigurationArguments): void {
+        this.args = args;
+    }
+
+    public customRequest(command: string, response: DebugProtocol.Response, args: any): boolean {
+        return false;
+    }
+
+    public initCommands(): string[] {
+        const gdbport = this.ports[createPortName(this.args.targetProcessor)];
+        return [
+            `target-select extended-remote localhost:${gdbport}`
+        ];
+    }
+
+    public launchCommands(): string[] {
+        const commands = [
+            'interpreter-exec console "monitor reset halt"',
+            'target-download',
+            'interpreter-exec console "monitor reset halt"',
+            'enable-pretty-printing'       
+        ];
+        return commands;
+    }
+
+    public attachCommands(): string[] {
+        const commands = [
+            'interpreter-exec console "monitor halt"',
+            'enable-pretty-printing'
+        ];
+        return commands;
+    }
+
+    public restartCommands(): string[] {
+        const commands: string[] = [
+            'interpreter-exec console "monitor reset halt"'
+        ];
+        return commands;
+    }
+
+    public swoCommands(): string[] {
+        const commands = [];
+        // if (this.args.swoConfig.enabled && this.args.swoConfig.source !== 'probe') {
+        //     const swocommands = this.SWOConfigurationCommands();
+        //     commands.push(...swocommands);
+        // }
+        return commands;
+    }
+
+    // private SWOConfigurationCommands(): string[] {
+    //     const portMask = '0x' + calculatePortMask(this.args.swoConfig.decoders).toString(16);
+    //     const swoFrequency = this.args.swoConfig.swoFrequency;
+    //     const cpuFrequency = this.args.swoConfig.cpuFrequency;
+
+    //     const ratio = Math.floor(cpuFrequency / swoFrequency) - 1;
+        
+    //     const commands: string[] = [
+    //         'EnableITMAccess',
+    //         `BaseSWOSetup ${ratio}`,
+    //         'SetITMId 1',
+    //         'ITMDWTTransferEnable',
+    //         'DisableITMPorts 0xFFFFFFFF',
+    //         `EnableITMPorts ${portMask}`,
+    //         'EnableDWTSync',
+    //         'ITMSyncEnable',
+    //         'ITMGlobalEnable'
+    //     ];
+
+    //     commands.push(this.args.swoConfig.profile ? 'EnablePCSample' : 'DisablePCSample');
+        
+    //     return commands.map((c) => `interpreter-exec console "${c}"`);
+    // }
+
+    public serverExecutable(): string {
+        if (this.args.serverpath) { return this.args.serverpath; }
+        else { return os.platform() === 'win32' ? 'ST-LINK_gdbserver.exe' : 'ST-LINK_gdbserver'; }
+    }
+
+    public serverArguments(): string[] {
+        const gdbport = this.ports['gdbPort'];
+
+        let serverargs = ['-p', gdbport.toString()];
+
+        // The -cp parameter is mandatory and STM32CubeProgrammer must be installed
+        let stm32cubeprogrammer;
+        if (this.args.stm32cubeprogrammer) {
+            stm32cubeprogrammer = this.args.stm32cubeprogrammer;
+        } else {
+            if (os.platform() === 'win32') {
+                stm32cubeprogrammer = process.env.ProgramFiles + '\\STMicroelectronics\\STM32Cube\\STM32CubeProgrammer\\bin';
+            } else {
+                stm32cubeprogrammer = '/usr/local/STMicroelectronics/STM32Cube/STM32CubeProgrammer/bin';
+            }
+        }
+        serverargs.push('-cp', stm32cubeprogrammer);
+
+        if (this.args.interface !== 'jtag') {
+            serverargs.push('--swd');
+        }
+
+        if (this.args.serialNumber) {
+            serverargs.push('--serial-number', this.args.serialNumber);
+        }
+        
+        if (this.args.serverArgs) {
+            serverargs = serverargs.concat(this.args.serverArgs);
+        }
+
+        return serverargs;
+    }
+
+    public initMatch(): RegExp {
+        return /Listening at \*/g;
+    }
+
+    public serverLaunchStarted(): void {}
+    public serverLaunchCompleted(): void {
+        // if (this.args.swoConfig.enabled && this.args.swoConfig.source !== 'probe') {
+        //     this.emit('event', new SWOConfigureEvent({
+        //         type: 'serial',
+        //         device: this.args.swoConfig.source,
+        //         baudRate: this.args.swoConfig.swoFrequency
+        //     }));
+        // }
+    }
+    
+    public debuggerLaunchStarted(): void {}
+    public debuggerLaunchCompleted(): void {}
+}

--- a/src/stlink.ts
+++ b/src/stlink.ts
@@ -1,7 +1,51 @@
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { GDBServerController, ConfigurationArguments, SWOConfigureEvent, calculatePortMask, createPortName } from './common';
 import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
 import { EventEmitter } from 'events';
+
+
+// Path of the top-level STM32CubeIDE installation directory, os-dependant
+const ST_DIR = os.platform() === 'win32' ? 'c:\\ST' : '/opt/st';
+
+const STMCUBEIDE_REGEX = /^STM32CubeIDE_(.+)$/;
+// Example: c:\ST\STM32CubeIDE_1.5.0\
+const GDB_REGEX = /com\.st\.stm32cube\.ide\.mcu\.externaltools\.stlink-gdb-server\.(.+)/;
+// Example: c:\ST\STM32CubeIDE_1.5.0\STM32CubeIDE\plugins\com.st.stm32cube.ide.mcu.externaltools.stlink-gdb-server.win32_1.5.0.202011040924\
+const PROG_REGEX = /com\.st\.stm32cube\.ide\.mcu\.externaltools\.cubeprogrammer\.(.+)/;
+// Example: c:\ST\STM32CubeIDE_1.5.0\STM32CubeIDE\plugins\com.st.stm32cube.ide.mcu.externaltools.cubeprogrammer.win32_1.5.0.202011040924\
+const GCC_REGEX = /com\.st\.stm32cube\.ide\.mcu\.externaltools\.gnu-tools-for-stm32\.(.+)/;
+// Example: c:\ST\STM32CubeIDE_1.5.0\STM32CubeIDE\plugins\com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.7-2018-q2-update.win32_1.5.0.202011040924\
+
+
+/**
+ * Resolves the path location of a STM32CubeIDE plugin irrespective of version number.
+ * Works for most recent version STM32CubeIDE_1.4.0 and STM32CubeIDE_1.5.0.
+ */
+function resolveCubePath(dirSegments, regex, suffix, executable = '')
+{
+    let dir = path.join(...dirSegments);
+    let resolvedDir;
+    try {
+        for (let subDir of fs.readdirSync(dir, { withFileTypes: true }).sort()) {
+            if (!subDir.isDirectory())
+                continue;
+            let match = subDir.name.match(regex);
+            if (match) {
+                let fullPath = path.join(dir, match[0], suffix, executable);
+                if (fs.existsSync(fullPath)) {
+                    resolvedDir = fullPath;
+                }
+            }
+        }
+    }
+    catch(error) {
+        // Ignore
+    }
+    return resolvedDir ? resolvedDir : executable;
+}
+
 
 export class STLinkServerController extends EventEmitter implements GDBServerController {
     public readonly name: string = 'ST-LINK';
@@ -9,9 +53,16 @@ export class STLinkServerController extends EventEmitter implements GDBServerCon
 
     private args: ConfigurationArguments;
     private ports: { [name: string]: number };
+    private static readonly stmCubeIdeDir: string = resolveCubePath([ST_DIR], STMCUBEIDE_REGEX, 'STM32CubeIDE');
+
+
+    public static getArmToolchainPath(): string {
+        // Try to resolve gcc location
+        return resolveCubePath([this.stmCubeIdeDir, 'plugins'], GCC_REGEX, 'tools/bin'); 
+    }
 
     constructor() {
-        super();
+        super();        
     }
 
     public setPorts(ports: { [name: string]: number }): void {
@@ -93,7 +144,7 @@ export class STLinkServerController extends EventEmitter implements GDBServerCon
 
     public serverExecutable(): string {
         if (this.args.serverpath) { return this.args.serverpath; }
-        else { return os.platform() === 'win32' ? 'ST-LINK_gdbserver.exe' : 'ST-LINK_gdbserver'; }
+        else { return resolveCubePath([STLinkServerController.stmCubeIdeDir, 'plugins'], GDB_REGEX, 'tools/bin', os.platform() === 'win32' ? 'ST-LINK_gdbserver.exe' : 'ST-LINK_gdbserver') }
     }
 
     public serverArguments(): string[] {
@@ -101,18 +152,21 @@ export class STLinkServerController extends EventEmitter implements GDBServerCon
 
         let serverargs = ['-p', gdbport.toString()];
 
-        // The -cp parameter is mandatory and STM32CubeProgrammer must be installed
-        let stm32cubeprogrammer;
+        // The -cp parameter is mandatory and either STM32CubeProgrammer or STM32CubeProgrammer must be installed
         if (this.args.stm32cubeprogrammer) {
-            stm32cubeprogrammer = this.args.stm32cubeprogrammer;
+            serverargs.push('-cp', this.args.stm32cubeprogrammer);
         } else {
-            if (os.platform() === 'win32') {
-                stm32cubeprogrammer = process.env.ProgramFiles + '\\STMicroelectronics\\STM32Cube\\STM32CubeProgrammer\\bin';
-            } else {
-                stm32cubeprogrammer = '/usr/local/STMicroelectronics/STM32Cube/STM32CubeProgrammer/bin';
+            let stm32cubeprogrammer = resolveCubePath([STLinkServerController.stmCubeIdeDir, 'plugins'], PROG_REGEX, 'tools/bin');
+            // Fallback to standalone programmer if no STMCube32IDE is installed:
+            if (!stm32cubeprogrammer) {
+                if (os.platform() === 'win32') {
+                    stm32cubeprogrammer = process.env.ProgramFiles + '\\STMicroelectronics\\STM32Cube\\STM32CubeProgrammer\\bin';
+                } else {
+                    stm32cubeprogrammer = '/usr/local/STMicroelectronics/STM32Cube/STM32CubeProgrammer/bin';
+                }
             }
+            serverargs.push('-cp', stm32cubeprogrammer);
         }
-        serverargs.push('-cp', stm32cubeprogrammer);
 
         if (this.args.interface !== 'jtag') {
             serverargs.push('--swd');


### PR DESCRIPTION
After commenting last night that it would be nice to have that feature, I gave it a go to implement it. The only issue is that ST's STMCubeIde needs to be installed as a dependency and ST does not make it easy to determine the correct path names for the 3 tools involved (namely `ST-LINK_gdbserver`, `arm-none-eabi-gdb`, `STM32_Programmer`) . So those have to be added by hand by the user as settings. I wish this could be done automatically.

So either the tools are on the PATH or they have to be configured like this:
```
           "armToolchainPath": "c:/ST/STM32CubeIDE_1.5.0/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.7-2018-q2-update.win32_1.5.0.202011040924/tools/bin",
            "stm32cubeprogrammer": "c:/ST/STM32CubeIDE_1.5.0/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.cubeprogrammer.win32_1.5.0.202011040924/tools/bin",
            "serverpath": "c:/ST/STM32CubeIDE_1.5.0/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.stlink-gdb-server.win32_1.5.0.202011040924/tools/bin/ST-LINK_gdbserver.exe"
```