### PR TITLE
Update external.ts

### DIFF
--- a/src/external.ts
+++ b/src/external.ts
@@ -37,7 +37,6 @@ export class ExternalServerController extends EventEmitter implements GDBServerC
         const commands = [
             'interpreter-exec console "monitor reset halt"',
             'target-download',
-            'interpreter-exec console "monitor reset halt"',
             'enable-pretty-printing'
         ];
 


### PR DESCRIPTION
When application loaded to RAM memory, Reset after target download will clear the RAM memory. Because of this, debug will not be happen.