### PR TITLE
bugfix: handle cancel in set format command

### DIFF
--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -332,6 +332,8 @@ export class CortexDebugExtension {
             { label: 'Decimal', description: 'Format value in decimal', value: NumberFormat.Decimal },
             { label: 'Binary', description: 'Format value in binary', value: NumberFormat.Binary }
         ]);
+        if (result === undefined)
+            return;
 
         node.format = result.value;
         this.peripheralProvider.refresh();


### PR DESCRIPTION
Abort to set the peripheral format if the quickpick result is undefined.

Before the fix:
![Screenshot_2021-01-21_01-35-31](https://user-images.githubusercontent.com/511857/105220063-c6452700-5b89-11eb-8e72-ef94b1a9b66e.png)
