### PR TITLE
issue #370: add toggle pin button to peripherals

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,9 +132,14 @@
                 "title": "Refresh"
             },
             {
-                "command": "cortex-debug.peripherals.togglePin",
-                "title": "Toggle Pin",
+                "command": "cortex-debug.peripherals.pin",
+                "title": "Pin",
                 "icon": "$(pin)"
+            },
+            {
+                "command": "cortex-debug.peripherals.unpin",
+                "title": "Unpin",
+                "icon": "$(pinned)"
             },
             {
                 "category": "Cortex-Debug",
@@ -1453,7 +1458,11 @@
                     "when": "false"
                 },
                 {
-                    "command": "cortex-debug.peripherals.togglePin",
+                    "command": "cortex-debug.peripherals.pin",
+                    "when": "false"
+                },
+                {
+                    "command": "cortex-debug.peripherals.unpin",
                     "when": "false"
                 },
                 {
@@ -1523,11 +1532,16 @@
                 },
                 {
                     "command": "cortex-debug.peripherals.forceRefresh",
-                    "when": "view == cortex-debug.peripherals && viewItem == peripheral"
+                    "when": "view == cortex-debug.peripherals && viewItem =~ /peripheral.*/"
                 },
                 {
-                    "command": "cortex-debug.peripherals.togglePin",
+                    "command": "cortex-debug.peripherals.pin",
                     "when": "view == cortex-debug.peripherals && viewItem == peripheral",
+                    "group": "inline"
+                },
+                {
+                    "command": "cortex-debug.peripherals.unpin",
+                    "when": "view == cortex-debug.peripherals && viewItem == peripheral.pinned",
                     "group": "inline"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -132,6 +132,11 @@
                 "title": "Refresh"
             },
             {
+                "command": "cortex-debug.peripherals.togglePin",
+                "title": "Toggle Pin",
+                "icon": "$(pin)"
+            },
+            {
                 "category": "Cortex-Debug",
                 "command": "cortex-debug.examineMemory",
                 "title": "View Memory"
@@ -1448,6 +1453,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "cortex-debug.peripherals.togglePin",
+                    "when": "false"
+                },
+                {
                     "command": "cortex-debug.registers.copyValue",
                     "when": "false"
                 },
@@ -1515,6 +1524,11 @@
                 {
                     "command": "cortex-debug.peripherals.forceRefresh",
                     "when": "view == cortex-debug.peripherals && viewItem == peripheral"
+                },
+                {
+                    "command": "cortex-debug.peripherals.togglePin",
+                    "when": "view == cortex-debug.peripherals && viewItem == peripheral",
+                    "group": "inline"
                 },
                 {
                     "command": "cortex-debug.registers.copyValue",

--- a/src/common.ts
+++ b/src/common.ts
@@ -13,6 +13,7 @@ export interface NodeSetting {
     node: string;
     expanded?: boolean;
     format?: NumberFormat;
+    pinned?: boolean;
 }
 
 export class AdapterOutputEvent extends Event implements DebugProtocol.Event {

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -72,7 +72,8 @@ export class CortexDebugExtension {
             vscode.commands.registerCommand('cortex-debug.peripherals.copyValue', this.peripheralsCopyValue.bind(this)),
             vscode.commands.registerCommand('cortex-debug.peripherals.setFormat', this.peripheralsSetFormat.bind(this)),
             vscode.commands.registerCommand('cortex-debug.peripherals.forceRefresh', this.peripheralsForceRefresh.bind(this)),
-            vscode.commands.registerCommand('cortex-debug.peripherals.togglePin', this.peripheralsTogglePin.bind(this)),
+            vscode.commands.registerCommand('cortex-debug.peripherals.pin', this.peripheralsTogglePin.bind(this)),
+            vscode.commands.registerCommand('cortex-debug.peripherals.unpin', this.peripheralsTogglePin.bind(this)),
             
             vscode.commands.registerCommand('cortex-debug.registers.copyValue', this.registersCopyValue.bind(this)),
             

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -72,6 +72,7 @@ export class CortexDebugExtension {
             vscode.commands.registerCommand('cortex-debug.peripherals.copyValue', this.peripheralsCopyValue.bind(this)),
             vscode.commands.registerCommand('cortex-debug.peripherals.setFormat', this.peripheralsSetFormat.bind(this)),
             vscode.commands.registerCommand('cortex-debug.peripherals.forceRefresh', this.peripheralsForceRefresh.bind(this)),
+            vscode.commands.registerCommand('cortex-debug.peripherals.togglePin', this.peripheralsTogglePin.bind(this)),
             
             vscode.commands.registerCommand('cortex-debug.registers.copyValue', this.registersCopyValue.bind(this)),
             
@@ -344,6 +345,11 @@ export class CortexDebugExtension {
         node.getPeripheral().updateData().then((e) => {
             this.peripheralProvider.refresh();
         });
+    }
+
+    private async peripheralsTogglePin(node: PeripheralBaseNode): Promise<void> {
+        this.peripheralProvider.togglePinPeripheral(node);
+        this.peripheralProvider.refresh();
     }
 
     // Registers

--- a/src/frontend/svd.ts
+++ b/src/frontend/svd.ts
@@ -83,15 +83,7 @@ export class SVDParser {
                         }
                     }
 
-                    peripherials.sort((p1, p2) => {
-                        if (p1.groupName > p2.groupName) { return 1; }
-                        else if (p1.groupName < p2.groupName) { return -1; }
-                        else {
-                            if (p1.name > p2.name) { return 1; }
-                            else if (p1.name < p2.name) { return -1; }
-                            else { return 0; }
-                        }
-                    });
+                    peripherials.sort(PeripheralNode.compare);
 
                     for (const p of peripherials) {
                         p.markAddresses();

--- a/src/frontend/views/nodes/basenode.ts
+++ b/src/frontend/views/nodes/basenode.ts
@@ -25,11 +25,13 @@ export abstract class BaseNode {
 
 export abstract class PeripheralBaseNode extends BaseNode {
     public format: NumberFormat;
+    public pinned: boolean;
     public readonly name: string;
     
     constructor(protected readonly parent?: PeripheralBaseNode) {
         super(parent);
         this.format = NumberFormat.Auto;
+        this.pinned = false;
     }
 
     public selected(): Thenable<boolean> {

--- a/src/frontend/views/nodes/peripheralnode.ts
+++ b/src/frontend/views/nodes/peripheralnode.ts
@@ -1,4 +1,4 @@
-import { TreeItem, TreeItemCollapsibleState } from 'vscode';
+import { TreeItem, TreeItemCollapsibleState, ThemeIcon } from 'vscode';
 import { AccessType } from '../../svd';
 import { PeripheralBaseNode } from './basenode';
 import { AddrRange, AddressRangesInUse } from '../../addrranges';
@@ -52,13 +52,18 @@ export class PeripheralNode extends PeripheralBaseNode {
     public getPeripheral(): PeripheralBaseNode {
         return this;
     }
+
     public getTreeItem(): TreeItem | Promise<TreeItem> {
         const label = `${this.name} @ ${hexFormat(this.baseAddress)}`;
         const item = new TreeItem(label, this.expanded ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.Collapsed);
         item.contextValue = 'peripheral';
         item.tooltip = this.description;
+        if (this.pinned)
+            // TODO: requires to update vscode to new typing dependency
+            item.iconPath = new ThemeIcon('pinned');
         return item;
     }
+
     public getCopyValue(): string {
         throw new Error('Method not implemented.');
     }
@@ -166,8 +171,13 @@ export class PeripheralNode extends PeripheralBaseNode {
     public saveState(path?: string): NodeSetting[] {
         const results: NodeSetting[] = [];
 
-        if (this.format !== NumberFormat.Auto || this.expanded) {
-            results.push({ node: `${this.name}`, expanded: this.expanded, format: this.format });
+        if (this.format !== NumberFormat.Auto || this.expanded || this.pinned) {
+            results.push({
+                node: `${this.name}`,
+                expanded: this.expanded,
+                format: this.format,
+                pinned: this.pinned
+            });
         }
 
         this.children.forEach((c) => {
@@ -188,5 +198,19 @@ export class PeripheralNode extends PeripheralBaseNode {
 
     public performUpdate(): Thenable<any> {
         throw new Error('Method not implemented.');
+    }
+
+    public static compare(p1: PeripheralNode, p2: PeripheralNode): number {
+        if ((p1.pinned && p2.pinned) || (!p1.pinned && !p2.pinned)) {
+            // none or both peripherals are pinned, sort by name prioritizing groupname
+            if (p1.groupName !== p2.groupName)
+                return p1.groupName > p2.groupName ? 1 : -1;
+            else if (p1.name !== p2.name)
+                return p1.name > p2.name ? 1 : -1;
+            else
+                return 0;
+        } else {
+            return p1.pinned ? -1 : 1;
+        }
     }
 }

--- a/src/frontend/views/nodes/peripheralnode.ts
+++ b/src/frontend/views/nodes/peripheralnode.ts
@@ -1,4 +1,4 @@
-import { TreeItem, TreeItemCollapsibleState, ThemeIcon } from 'vscode';
+import { TreeItem, TreeItemCollapsibleState } from 'vscode';
 import { AccessType } from '../../svd';
 import { PeripheralBaseNode } from './basenode';
 import { AddrRange, AddressRangesInUse } from '../../addrranges';
@@ -56,11 +56,8 @@ export class PeripheralNode extends PeripheralBaseNode {
     public getTreeItem(): TreeItem | Promise<TreeItem> {
         const label = `${this.name} @ ${hexFormat(this.baseAddress)}`;
         const item = new TreeItem(label, this.expanded ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.Collapsed);
-        item.contextValue = 'peripheral';
+        item.contextValue = this.pinned ? 'peripheral.pinned' : 'peripheral';
         item.tooltip = this.description;
-        if (this.pinned)
-            // TODO: requires to update vscode to new typing dependency
-            item.iconPath = new ThemeIcon('pinned');
         return item;
     }
 

--- a/src/frontend/views/peripheral.ts
+++ b/src/frontend/views/peripheral.ts
@@ -98,9 +98,11 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
                                         const node = this.findNodeByPath(s.node);
                                         if (node) {
                                             node.expanded = s.expanded || false;
+                                            node.pinned = s.pinned || false;
                                             node.format = s.format;
                                         }
                                     });
+                                    this.peripherials.sort(PeripheralNode.compare);
                                     this._onDidChangeTreeData.fire();
                                 }
                             }, (error) => {
@@ -153,5 +155,10 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
 
     public debugContinued() {
         
+    }
+
+    public togglePinPeripheral(node: PeripheralBaseNode) {
+        node.pinned = !node.pinned;
+        this.peripherials.sort(PeripheralNode.compare);
     }
 }


### PR DESCRIPTION
This solves #370. It allows to pin a peripheral node to the top of the list for quicker access. Useful when debugging some peripheral to avoid scrolling or searching it every time the debug session is restarted. The state is persisted across debugging sessions.

Demo (I restarted the debugging session to show the state is persisted)
![pin-peripherals](https://user-images.githubusercontent.com/511857/105366832-5d65b980-5c32-11eb-880c-d6a54b30c263.gif)

Although there is a **TODO**. In order to use `ThemeIcon` is needed to update `vscode` dependency to use `@types/vscode` as described [here](https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest). I tried this already (removing `vscode` and installing `@types/vscode@1.34.0` to keep the same API as current) but I believe the tests need to be updated as well. The issue with `ThemeIcon` is that in current dependency, the constructor is private, but somehow in the types version (also v1.34) is public.

I can address this update in a separate pr and merge this one afterwards. But I may need some quick support from you @Marus in order to migrate the tests as well, if it's needed.