### PR TITLE
issue #389: replace runToMain with runToEntryPoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,7 +258,7 @@
                                 "default": [],
                                 "type": "array",
                                 "items": "string",
-                                "description": "Additional GDB Commands to be executed at the end of the start sequence, after a debug session has already started and runToMain is false."
+                                "description": "Additional GDB Commands to be executed at the end of the start sequence, after a debug session has already started and runToEntryPoint is not specified."
                             },
                             "postRestartSessionCommands": {
                                 "default": [],
@@ -835,7 +835,7 @@
                                 "default": [],
                                 "type": "array",
                                 "items": "string",
-                                "description": "Additional GDB Commands to be executed at the end of the start sequence, after a debug session has already started and runToMain is false."
+                                "description": "Additional GDB Commands to be executed at the end of the start sequence, after a debug session has already started and runToEntryPoint is not specified."
                             },
                             "postRestartSessionCommands": {
                                 "default": [],
@@ -912,9 +912,14 @@
                                 "type": "string"
                             },
                             "runToMain": {
-                                "description": "If enabled the debugger will run until it the start of the main function.",
+                                "description": "Deprecated: please use 'runToEntryPoint' instead.",
                                 "type": "boolean",
                                 "default": false
+                            },
+                            "runToEntryPoint": {
+                                "description": "If enabled the debugger will run until the start of the given function.",
+                                "type": "string",
+                                "default": "main"
                             },
                             "demangle": {
                                 "description": "Experimental: If enabled the debugger will demangle C++ names.",

--- a/src/common.ts
+++ b/src/common.ts
@@ -117,7 +117,8 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     interface: string;
     targetId: string | number;
     cmsisPack: string;
-    runToMain: boolean;
+    runToMain: boolean;         // Deprecated: kept here for backwards compatibility
+    runToEntryPoint: string;
     flattenAnonymous: boolean;
     registerUseNaturalFormat: boolean;
 

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -59,7 +59,9 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
         if (!config.postAttachCommands) { config.postAttachCommands = []; }
         if (!config.preRestartCommands) { config.preRestartCommands = []; }
         if (!config.postRestartCommands) { config.postRestartCommands = []; }
-        if (config.request !== 'launch') { config.runToMain = false; }
+        if (config.request !== 'launch') { config.runToEntryPoint = null; }
+        else if (config.runToEntryPoint) { config.runToEntryPoint = config.runToEntryPoint.trim(); }
+        else if (config.runToMain) { config.runToEntryPoint = 'main'; }
 
         switch (type) {
             case 'jlink':

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -395,7 +395,7 @@ export class GDBDebugSession extends DebugSession {
                     this.handleMsg('log', dbgMsg);
                 }
 
-                this.disableSendStoppedEvents = (!attach && this.args.runToMain) ? true : false;
+                this.disableSendStoppedEvents = (!attach && this.args.runToEntryPoint) ? true : false;
                 this.miDebugger.connect(this.args.cwd, this.args.executable, commands).then(() => {
                     this.started = true;
                     this.serverController.debuggerLaunchCompleted();
@@ -422,8 +422,8 @@ export class GDBDebugSession extends DebugSession {
                         }
                     };
 
-                    if (this.args.runToMain) {
-                        this.miDebugger.sendCommand('break-insert -t --function main').then(() => {
+                    if (this.args.runToEntryPoint) {
+                        this.miDebugger.sendCommand(`break-insert -t --function ${this.args.runToEntryPoint}`).then(() => {
                             this.miDebugger.once('generic-stopped', launchComplete);
                             // To avoid race conditions between finishing configuration, we should stay
                             // in stopped mode. Or, we end up clobbering the stopped event that might come
@@ -437,9 +437,9 @@ export class GDBDebugSession extends DebugSession {
                                 });
                             }
                         }, (err) => {
-                            // If failed to set the temporary breakpoint (e.g. function main does not exist),
+                            // If failed to set the temporary breakpoint (e.g. function does not exist)
                             // complete the launch as if the breakpoint had not being defined
-                            this.handleMsg('log', `launch.json: "runToMain" enabled but "main" function does not exist? '${err.toString()}\n`);
+                            this.handleMsg('log', `launch.json: "runToEntryPoint" enabled but function "${this.args.runToEntryPoint}" does not exist? '${err.toString()}\n`);
                             launchComplete();
                             runPostStartSession();
                         });


### PR DESCRIPTION
Replace runToMain with two configuration options: runToEntryPoint
(default to false) and entryPointName (default to main).

runToMain become a deprecated configuration option which would set those two
if it was set and also the newer options not given. If both runToMain
and runToEntryPoint are enabled, runToEntryPoint takes precedence.
