### PR TITLE
Fix argument for selecting JTAG or SWD interface for P&E Micro GDB server.

### DIFF
--- a/src/pemicro.ts
+++ b/src/pemicro.ts
@@ -100,8 +100,8 @@ export class PEServerController extends EventEmitter implements GDBServerControl
             serverargs.push(`-kernal=${this.args.rtos}`);
         }
 
-        if (this.args.interface) {
-            serverargs.push(`-interface=${this.args.interface}`);
+        if (this.args.interface === 'jtag') {
+            serverargs.push(`-usejtag`);
         }
 
         if (this.args.configFiles) {


### PR DESCRIPTION
The Argument "-interface" for P&E Micro GDB server pegdbserver_console is used incorrectly.
This argument is used to select a manufacturer's hardware interface such as USBMULTILINK, CYCLONE, TRACELINK, OPENSDA.

However, in order to select debug interface no argument is needed for SWD, and the valid argument that selects jtag interface is: "-usejtag".

This change is necessary to be consistent with the configuration field "interface" in launch.json, which is an enumeration between the strings: 'swd' or 'jtag'.

The handling of the GDB P&E Micro server argument "-interface" and "-port" should be done with specific fields.