### PR TITLE
Add support for 'Jump to Cursor' command.

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -314,6 +314,20 @@ export class MI2 extends EventEmitter implements IBackend {
         });
     }
 
+    public goto(filename: string, line: number): Thenable<boolean> {
+		if (trace) {
+			this.log('stderr', 'goto');
+        }
+		return new Promise((resolve, reject) => {
+			const target: string = '"' + (filename ? escape(filename) + ":" : "") + line + '"';
+			this.sendCommand("break-insert -t " + target).then(() => {
+				this.sendCommand("exec-jump " + target).then((info) => {
+					resolve(info.resultRecords.resultClass == "running");
+				}, reject);
+			}, reject);
+		});
+	}
+
     public restart(commands: string[]): Thenable<boolean> {
         if (trace) {
             this.log('stderr', 'restart');

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -166,6 +166,7 @@ export class GDBDebugSession extends DebugSession {
         response.body.supportsEvaluateForHovers = true;
         response.body.supportsSetVariable = true;
         response.body.supportsRestartRequest = true;
+        response.body.supportsGotoTargetsRequest = true;        
         this.sendResponse(response);
     }
 
@@ -2080,6 +2081,22 @@ export class GDBDebugSession extends DebugSession {
             });
         }
     }
+
+	protected gotoTargetsRequest(response: DebugProtocol.GotoTargetsResponse, args: DebugProtocol.GotoTargetsArguments): void {
+		this.miDebugger.goto(args.source.path, args.line).then(done => {
+			response.body = {
+				targets: [{
+					id: 1,
+					label: args.source.name,
+					column: args.column,
+					line : args.line
+				}]
+			};
+			this.sendResponse(response);
+		}, msg => {
+			this.sendErrorResponse(response, 16, `Could not jump: ${msg}`);
+		});
+	}
 }
 
 function prettyStringArray(strings) {


### PR DESCRIPTION
I backported this feature from [WebFreak001/code-debug](https://github.com/WebFreak001/code-debug): [src/mibase.ts](https://github.com/WebFreak001/code-debug/tree/master/src/mibase.ts#L651-L665) and [src/backend/mi2/mi2.ts](https://github.com/WebFreak001/code-debug/tree/master/src/backend/mi2/mi2.ts#L484-L495).

`supportsGotoTargetsRequest` activates the _Jump to Cursor_ command in the Command Palette of Visual Studio Code and in the source code file context menu.