### PR TITLE
Add Zephyr RTOS support for JLink

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
                             },
                             "rtos": {
                                 "default": null,
-                                "description": "RTOS being used. For JLink this can be FreeRTOS, embOS or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be eCos, ThreadX, FreeRTOS, ChibiOS, embKernel, mqx, or uCOS-III.",
+                                "description": "RTOS being used. For JLink this can be FreeRTOS, embOS, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be eCos, ThreadX, FreeRTOS, ChibiOS, embKernel, mqx, or uCOS-III.",
                                 "type": "string"
                             },
                             "armToolchainPath": {
@@ -893,7 +893,7 @@
                             },
                             "rtos": {
                                 "default": null,
-                                "description": "RTOS being used. For JLink this can be FreeRTOS, embOS or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be eCos, ThreadX, FreeRTOS, ChibiOS, embKernel, mqx, or uCOS-III.",
+                                "description": "RTOS being used. For JLink this can be FreeRTOS, embOS, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be eCos, ThreadX, FreeRTOS, ChibiOS, embKernel, mqx, or uCOS-III.",
                                 "type": "string"
                             },
                             "armToolchainPath": {

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import { STLinkServerController } from './../stlink';
 
 const OPENOCD_VALID_RTOS: string[] = ['eCos', 'ThreadX', 'FreeRTOS', 'ChibiOS', 'embKernel', 'mqx', 'uCOS-III', 'auto'];
-const JLINK_VALID_RTOS: string[] = ['FreeRTOS', 'embOS', 'ChibiOS'];
+const JLINK_VALID_RTOS: string[] = ['FreeRTOS', 'embOS', 'ChibiOS', 'Zephyr'];
 
 export class CortexDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
     constructor(private context: vscode.ExtensionContext) {}
@@ -165,7 +165,7 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
             if (JLINK_VALID_RTOS.indexOf(config.rtos) === -1) {
                 if (!fs.existsSync(config.rtos)) {
                     // tslint:disable-next-line:max-line-length
-                    return 'The following RTOS values are supported by J-Link: FreeRTOS or embOS. A custom plugin can be used by supplying a complete path to a J-Link GDB Server Plugin.';
+                    return `The following RTOS values are supported by J-Link: ${JLINK_VALID_RTOS.join(', ')}. A custom plugin can be used by supplying a complete path to a J-Link GDB Server Plugin.`;
                 }
             }
             else {


### PR DESCRIPTION
JLink version 7.11b adds GDB Server support for the Zephyr RTOS.
Add Zephyr to the list of supported RTOS libraries.