### PR TITLE
Add NuttX RTOS support for OpenOCD

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
                             },
                             "rtos": {
                                 "default": null,
-                                "description": "RTOS being used. For JLink this can be FreeRTOS, embOS, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be eCos, ThreadX, FreeRTOS, ChibiOS, embKernel, mqx, or uCOS-III.",
+                                "description": "RTOS being used. For JLink this can be FreeRTOS, embOS, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be eCos, ThreadX, FreeRTOS, ChibiOS, embKernel, mqx, uCOS-III, or nuttx.",
                                 "type": "string"
                             },
                             "armToolchainPath": {

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { STLinkServerController } from './../stlink';
 
-const OPENOCD_VALID_RTOS: string[] = ['eCos', 'ThreadX', 'FreeRTOS', 'ChibiOS', 'embKernel', 'mqx', 'uCOS-III', 'auto'];
+const OPENOCD_VALID_RTOS: string[] = ['eCos', 'ThreadX', 'FreeRTOS', 'ChibiOS', 'embKernel', 'mqx', 'uCOS-III', 'nuttx', 'auto'];
 const JLINK_VALID_RTOS: string[] = ['FreeRTOS', 'embOS', 'ChibiOS', 'Zephyr'];
 
 export class CortexDebugConfigurationProvider implements vscode.DebugConfigurationProvider {


### PR DESCRIPTION
OpenOCD added support for NuttX on version 0.11.0
http://openocd.org/2021/03/openocd-0-11-0-released/

NuttX capitalization all lowercase ("nuttx") as indicated
in the OpenOCD documentation:
http://openocd.org/doc-release/html/GDB-and-OpenOCD.html#RTOS-Support

Thanks!