### PR TITLE
SWO showOnStartup Fix

### DIFF
--- a/src/frontend/swo/decoders/console.ts
+++ b/src/frontend/swo/decoders/console.ts
@@ -13,14 +13,19 @@ export class SWOConsoleProcessor implements SWODecoder {
     public readonly format: string = 'console';
     private port: number;
     private encoding: string;
+    private showOutputTimer: any = null;
     
     constructor(config: SWOConsoleDecoderConfig) {
         this.port = config.port;
         this.encoding = config.encoding || 'utf8';
         this.output = vscode.window.createOutputChannel(`SWO: ${config.label || ''} [port: ${this.port}, type: console]`);
 
-        if (config.showOnStartup) {
-            this.output.show(true);
+        // A work-around. A blank display will appear if the output is shown immediately 
+        if (config.showOnStartup) {       
+            this.showOutputTimer = setTimeout(() => {
+                this.output.show(true);
+                this.showOutputTimer = null;
+            }, 1000);
         }
     }
 

--- a/src/frontend/swo/decoders/console.ts
+++ b/src/frontend/swo/decoders/console.ts
@@ -25,7 +25,7 @@ export class SWOConsoleProcessor implements SWODecoder {
             this.showOutputTimer = setTimeout(() => {
                 this.output.show(true);
                 this.showOutputTimer = null;
-            }, 1000);
+            }, 1);
         }
     }
 


### PR DESCRIPTION
The current cortex-debug has an SWO parameter "showOnStartup" that is intended to flag for the "panel" view to be switched to the SWO output. However, this does not currently work. If the "panel" is switched to the SWO output immediately after it is created, an unchanging black view will appear. Manually switching the view to another and back will then show the SWO output. The reason for the unchanging back view is unknown.

This fix works-around the issue by adding a timer to the SWO console startup code. One second after the console is started the timer will then switch the "panel" to the SWO output view.

This work-around is a hack, but it was the only obvious fix.