### PR TITLE
Support for `pyoocd` SWO over a TCP port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
 ChangeLog
 # V0.3.13
-* `"external"` server type now supports SWO. It works in the following way depending on `"source"`
-  * `"source": "probe"` -- We do not recommend this method as there are issues with File I/O buffering causing delays and stalls, especially on Windows. Use a `"socket"` instead. It will use a auto-created temporary file name.
-    * On Windows, it will use normal file-io
-    * On Linux/Mac, it will use an OS supported FIFO which is more efficient than a normal file
-  * `"source": "socket"` (best option if available)
-    * You MUST specify the `"swoPort": "[host:]port"` option in the `"swoConfig"`
-  * `"source": "file"`, then the file specified by `"swoPath"` will be used. Same caveats as when`"source"` is `"probe"` but you have control over the file-name
-* `"openocd"` server type will now use a TCP connection for SWO instead of file/fifo for a more reliable connection across all platforms. Port selection happens automatically. You can still use a serial port in which case, `"source": "serial"`.
-* Use the `pyocd gdbserver` to start the gdb-server instead of the `pyocd-gdbserver` executable. However, if you are using `serverpath` to specify path name to `pyocd-gdbserver` that will still work. Support for this backwards compatibility will be removed in the future. We recommend using the path-name to the `pyocd` itself or to have it in your PATH.
-* Many other minor fixes
+
+New Features:
+   * `"external"` server type now supports SWO. It works in the following way depending on `"source"`
+     * `"source": "probe"` -- We do not recommend this method as there are issues with File I/O buffering causing delays and stalls, especially on Windows. Use a `"socket"` instead. It will use a auto-created temporary file name.
+       * On Windows, it will use normal file-io
+       * On Linux/Mac, it will use an OS supported FIFO which is more efficient than a normal file
+     * `"source": "socket"` (best option if available)
+       * You MUST specify the `"swoPort": "[host:]port"` option in the `"swoConfig"`
+     * `"source": "file"`, then the file specified by `"swoPath"` will be used. Same caveats as when`"source"` is `"probe"` but you have control over the file-name
+   * `"openocd"` server type will now use a TCP port for SWO instead of file/fifo for a more reliable connection across all platforms. Port selection is automatically. You can still use a serial port in which case, `"source": "serial"`.
+   * Support for `pyoocd` SWO over a TCP port. You can specify the SWO source as `probe`. This is rather new for `pyocd`, so it hasn't been extensively tested.
+
+Bug fixes and minor changes:
+   * Use the `pyocd` executable with `gdbserver` as first aregument instead of the `pyocd-gdbserver` executable. This is a potentially breaking change but long overdue as the old use model has been deprecated by `pyocd` long ago.
+   * Few other minor changes
 
 # V0.3.12
 

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -266,12 +266,6 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
         if (config.board && !config.boardId) { config.boardId = config.board; }
         if (config.target && !config.targetId) { config.targetId = config.target; }
 
-        if (config.swoConfig.enabled && config.swoConfig.source === 'probe') {
-            vscode.window.showWarningMessage('SWO support is not available from the probe when using the PyOCD GDB server. Disabling SWO.');
-            config.swoConfig = { enabled: false, ports: [], cpuFrequency: 0, swoFrequency: 0 };
-            config.graphConfig = [];
-        }
-
         return null;
     }
 


### PR DESCRIPTION
You can specify the SWO source as `probe`. This is rather new for `pyocd`, so it hasn't been extensively tested.

This is rather new for `pyocd`, so it hasn't been extensively tested.