### PR TITLE
Accept undefined stop reason

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -179,7 +179,7 @@ export class MI2 extends EventEmitter implements IBackend {
                                         this.log('stderr', 'Program exited with code ' + parsed.record('exit-code'));
                                         this.emit('exited-normally', parsed);
                                     }
-                                    else {
+                                    else if (reason !== undefined) {
                                         this.log('console', 'Not implemented stop reason (assuming exception): ' + reason);
                                         this.emit('stopped', parsed);
                                     }

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -390,6 +390,7 @@ export class GDBDebugSession extends DebugSession {
                 this.miDebugger.once('debug-ready', () => {
                     this.debugReady = true;
                     this.attached = attach;
+                    this.stopped = true;
                 });
 
                 if (true) {


### PR DESCRIPTION
In some cases, the GDB client will not include a reason field in the
async stopped event. Most notably, the SEGGER JLink server program entry
stop event only does in some corner cases, and as a result, most JLink
launch sessions start in the reset code with the exception error widget.

![image](https://user-images.githubusercontent.com/7857838/127335530-a18faa1a-6dec-4181-b672-599f302fc9b2.png)

Additionally, as the GDB class relied on the erronous `stopped` event to
set `this.stopped`, the `setFunctionBreakpoints` request running after the
"Initialized" event will deadlock waiting for a "generic-stopped" event
that already occurred.

Add a `reason !== undefined` guard for the stopped event in MI2 to fall
back to a simple "generic-stopped" event for this scenario. Mark the
debugger as "stopped" when the debugger is ready to avoid deadlocking 
the configuration procedure without the invalid stop event.