### PR TITLE
Do not treat outOfBandRecords as responses

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -135,7 +135,7 @@ export class MI2 extends EventEmitter implements IBackend {
                     this.log('log', 'GDB -> App: ' + JSON.stringify(parsed));
                 }
                 let handled = false;
-                if (parsed.token !== undefined) {
+                if (parsed.token !== undefined && parsed.resultRecords) {
                     if (this.handlers[parsed.token]) {
                         this.handlers[parsed.token](parsed);
                         delete this.handlers[parsed.token];
@@ -693,7 +693,7 @@ export class MI2 extends EventEmitter implements IBackend {
         const sel = this.currentToken++;
         return new Promise((resolve, reject) => {
             this.handlers[sel] = (node: MINode) => {
-                if (node && node.resultRecords && node.resultRecords.resultClass === 'error') {
+                if (node.resultRecords.resultClass === 'error') {
                     if (suppressFailure) {
                         this.log('stderr', `WARNING: Error executing command '${command}'`);
                         resolve(node);


### PR DESCRIPTION
Checks incoming MI messages for resultRecords before treating them as
responses. In some cases, the server may issue outOfBandRecords with a
token, but no resultRecords. This can for instance happen when the
server wants to report progress on an event before it's finished.
JLink's target-download command does this, and without this extra check,
we'll go straight to `monitor reset` before the download is actually
finished.

JLink's target-download events look like this:

    {"token":8,"outOfBandRecord":[{"isStream":false,"type":"status","asyncClass":"download","output":[]}]}

Note the token (which matches the target-download command's token), and
the lack of a resultRecord. For my 250kB image, this event is issued 5
times before the resultRecord is issued.