### PR TITLE
Ensure .vscode directory when saving states

### DIFF
--- a/src/frontend/views/peripheral.ts
+++ b/src/frontend/views/peripheral.ts
@@ -24,14 +24,15 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
 
     }
 
-    private saveState(path: string): void {
+    private saveState(fspath: string): void {
         const state: NodeSetting[] = [];
         this.peripherials.forEach((p) => {
             state.push(... p.saveState());
         });
         
         try {
-            fs.writeFileSync(path, JSON.stringify(state), { encoding: 'utf8', flag: 'w' });
+            fs.mkdirSync(path.dirname(fspath), { recursive: true });
+            fs.writeFileSync(fspath, JSON.stringify(state), { encoding: 'utf8', flag: 'w' });
         }
         catch (e) {
             vscode.window.showWarningMessage(`Unable to save periperal preferences ${e}`);

--- a/src/frontend/views/registers.ts
+++ b/src/frontend/views/registers.ts
@@ -127,6 +127,7 @@ export class RegisterTreeProvider implements TreeDataProvider<BaseNode> {
         });
 
         try {
+            fs.mkdirSync(path.dirname(fspath), { recursive: true });
             fs.writeFileSync(fspath, JSON.stringify(state), { encoding: 'utf8', flag: 'w' });
         }
         catch (e) {


### PR DESCRIPTION
In certain workspace configuration the peripheral and register states
would be saved in a workspace folder's .vscode directory which does
not always exists. This change ensures creating that directory first.