### PR TITLE
Correct spelling of all hexadecimal references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,9 +232,9 @@ This is a pretty big release. The biggest change is to address C++ (and maybe Ru
 * Changed core registers to be displayed using their "natural" formatting:
 	* `rXX` in decimal
 	* `sXX` in floating point
-	* stack pointers (`sp`, `msp`, `psp`) in hexidecimal
-	* program counter (`pc`) in hexidecimal with corresponding symbol location if available
-	* xPSR/cPSR/Control in hexidecimal (this is overridden from the GDB defaults for those registers)
+	* stack pointers (`sp`, `msp`, `psp`) in hexadecimal
+	* program counter (`pc`) in hexadecimal with corresponding symbol location if available
+	* xPSR/cPSR/Control in hexadecimal (this is overridden from the GDB defaults for those registers)
 
 	Note that with this change the ability to set formatting for these registers has been disabled; a more flexible formatting solution will be re-added in the future. You can also use a Watch expression for a register to the desired $reg,format to get the format you desire. For instance `$r0,x` will display the register value of `r0` in hexadecimal format.
 * Major refactor of the code for the Core Register and Peripheral Register displays; along with bringing (hopefully) improved formatting and UX to this views will make the code much easier to maintain and expand in the future.

--- a/src/common.ts
+++ b/src/common.ts
@@ -11,7 +11,7 @@ export enum CortexDebugKeys {
 
 export enum NumberFormat {
     Auto = 0,
-    Hexidecimal,
+    Hexadecimal,
     Decimal,
     Binary
 }

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -328,7 +328,7 @@ export class CortexDebugExtension {
         }
 
         vscode.window.showInputBox({
-            placeHolder: 'Enter a valid C/gdb expression. Use 0x prefix for hexidecimal numbers',
+            placeHolder: 'Enter a valid C/gdb expression. Use 0x prefix for hexadecimal numbers',
             ignoreFocusOut: true,
             prompt: 'Memory Address'
         }).then(
@@ -341,7 +341,7 @@ export class CortexDebugExtension {
                 }
 
                 vscode.window.showInputBox({
-                    placeHolder: 'Enter a constant value. Prefix with 0x for hexidecimal format.',
+                    placeHolder: 'Enter a constant value. Prefix with 0x for hexadecimal format.',
                     ignoreFocusOut: true,
                     prompt: 'Length'
                 }).then(
@@ -401,7 +401,7 @@ export class CortexDebugExtension {
     private async peripheralsSetFormat(node: PeripheralBaseNode): Promise<void> {
         const result = await vscode.window.showQuickPick([
             { label: 'Auto', description: 'Automatically choose format (Inherits from parent)', value: NumberFormat.Auto },
-            { label: 'Hex', description: 'Format value in hexidecimal', value: NumberFormat.Hexidecimal },
+            { label: 'Hex', description: 'Format value in hexadecimal', value: NumberFormat.Hexadecimal },
             { label: 'Decimal', description: 'Format value in decimal', value: NumberFormat.Decimal },
             { label: 'Binary', description: 'Format value in binary', value: NumberFormat.Binary }
         ]);

--- a/src/frontend/views/nodes/peripheralfieldnode.ts
+++ b/src/frontend/views/nodes/peripheralfieldnode.ts
@@ -190,7 +190,7 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
             case NumberFormat.Binary:
                 formatted = binaryFormat(value, this.width);
                 break;
-            case NumberFormat.Hexidecimal:
+            case NumberFormat.Hexadecimal:
                 formatted = hexFormat(value, Math.ceil(this.width / 4), true);
                 break;
             default:
@@ -252,7 +252,7 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
                 return value.toString();
             case NumberFormat.Binary:
                 return binaryFormat(value, this.width);
-            case NumberFormat.Hexidecimal:
+            case NumberFormat.Hexadecimal:
                 return hexFormat(value, Math.ceil(this.width / 4), true);
             default:
                 return this.width >= 4 ? hexFormat(value, Math.ceil(this.width / 4), true) : binaryFormat(value, this.width);

--- a/src/frontend/views/nodes/peripheralregisternode.ts
+++ b/src/frontend/views/nodes/peripheralregisternode.ts
@@ -125,7 +125,7 @@ export class PeripheralRegisterNode extends PeripheralBaseNode {
             return mds;
         }
 
-        const hex = this.getFormattedValue(NumberFormat.Hexidecimal);
+        const hex = this.getFormattedValue(NumberFormat.Hexadecimal);
         const decimal = this.getFormattedValue(NumberFormat.Decimal);
         const binary = this.getFormattedValue(NumberFormat.Binary);
         


### PR DESCRIPTION
I know this is minor, but when using the Cortex debug extension today, I noticed the front-end spelling for hex formats was wrong, so I went to fix it and also fixed the other references within the extension. I checked to see if this was possibly some difference of dialect or locale but I couldn't find anything.