### PR TITLE
Delay JLink server startup to allow it to settle

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -267,7 +267,7 @@ export interface GDBServerController extends EventEmitter {
     serverArguments(): string[];
     initMatch(): RegExp;
     serverLaunchStarted(): void;
-    serverLaunchCompleted(): void;
+    serverLaunchCompleted(): Promise<void> | void;
     debuggerLaunchStarted(): void;
     debuggerLaunchCompleted(): void;
 }

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -398,14 +398,13 @@ export class GDBDebugSession extends DebugSession {
             }, GDBServer.SERVER_TIMEOUT);
 
             this.serverController.serverLaunchStarted();
-            this.server.init().then((started) => {
+            this.server.init().then(async (started) => {
                 if (timeout) {
                     clearTimeout(timeout);
                     timeout = null;
                 }
 
-                this.serverController.serverLaunchCompleted();
-                
+                await this.serverController.serverLaunchCompleted();
                 let gdbargs = ['-q', '--interpreter=mi2'];
                 gdbargs = gdbargs.concat(this.args.debuggerArgs || []);
 


### PR DESCRIPTION
Although the extension is looking for the JLink GDB server to emit a log
line saying that it's waiting for the GDB Client to connect, it's
actually not ready until about 400 milliseconds later.

Occasionally, the JLink Server to loses track of the debug chip's state
right at the beginning of the session, putting the entire server into an
invalid state until the debugger chip is reset with "monitor reset".
This behavior only occurs if the monitor reset command is issued before
400 milliseconds have passed since the "Waiting for GDB connection..."
line is emitted by the JLink Server.

The issue is easiest to recognize through a series of errors in the
Adapter output, where the JLink server reads 0xdeadbeef from all
registers, which is propagated to the UI, making it look like the
program counter is stuck at address 0xdeadbeef or 0xdeadbeee.

To prevent the JLink server from ever ending up in this state, delay the
GDB Client launch with 500ms in the serverLaunchCompleted call. To avoid
breaking the git blame for the entire GDBDebugSession's attachOrLaunch
function, make the server init handler asynchronous, and add an await on
the call to serverLaunchCompleted.