### PR TITLE
Breakpoints: Send responses for all requested breakpoints

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -438,7 +438,7 @@ export class MI2 extends EventEmitter implements IBackend {
                             if (result.resultRecords.resultClass === 'done') {
                                 resolve(breakpoint);
                             } else {
-                                resolve(null);
+                                reject(new MIError(result.result('msg') || 'Internal error', `Setting breakpoint condition`));
                             }
                         }, reject);
                     }
@@ -447,7 +447,7 @@ export class MI2 extends EventEmitter implements IBackend {
                     }
                 }
                 else {
-                    resolve(null);
+                    reject(new MIError(result.result('msg') || 'Internal error', `Setting breakpoint at ${location}`));
                 }
             }, reject);
         });


### PR DESCRIPTION
According to the DAP specification, the response to a Breakpoint
request should contain an entry for all requested breakpoints, including
those that won't be set.

Currently, the DAP server only returns entries for the breakpoints that
were successfully set, and returns an error if any of the break-insert
requests reported errors from the GDB server.

Change this to return unverified breakpoints for both erronous
break-inserts and ignored breakpoint requests. This makes the invalid
breakpoints show as greyed out in the UI, and removes the current error
toast for all debug setting. This is in line with the behavior of other
VS Code debuggers, like the NodeJS debugger.

Additionally fixes a bug in functionBreakpoints, where the debugger
returned the source parameter as a string, when it should be an object.