### PR TITLE
Add Azure (RTOS) as possible value for J-Link

### DIFF
--- a/debug_attributes.md
+++ b/debug_attributes.md
@@ -24,7 +24,7 @@
 | preRestartCommands | Common | Additional GDB Commands to be executed at the beginning of the restart sequence (after interrupting execution).
 | pvtRestartOrReset | Common | ????
 | request | Common | ????
-| rtos | Common | RTOS being used. For JLink this can be ChibiOS, embOS, FreeRTOS, NuttX, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be eCos, ThreadX, FreeRTOS, ChibiOS, embKernel, mqx, uCOS-III, nuttx or auto.
+| rtos | Common | RTOS being used. For JLink this can be Azure, ChibiOS, embOS, FreeRTOS, NuttX, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be ChibiOS, eCos, embKernel, FreeRTOS, mqx, nuttx, ThreadX, uCOS-III, or auto.
 | rttConfig | Common | SEGGER's Real Time Trace (RTT) and supported by JLink, OpenOCD and perhaps others in the future
 | runToEntryPoint | Common | If enabled the debugger will run until the start of the given function.
 | runToMain | Common | Deprecated: please use 'runToEntryPoint' instead.

--- a/package.json
+++ b/package.json
@@ -596,7 +596,7 @@
                             },
                             "rtos": {
                                 "default": null,
-                                "description": "RTOS being used. For JLink this can be ChibiOS, embOS, FreeRTOS, NuttX, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be eCos, ThreadX, FreeRTOS, ChibiOS, embKernel, mqx, uCOS-III, nuttx or auto.",
+                                "description": "RTOS being used. For JLink this can be Azure, ChibiOS, embOS, FreeRTOS, NuttX, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be ChibiOS, eCos, embKernel, FreeRTOS, mqx, nuttx, ThreadX, uCOS-III, or auto.",
                                 "type": "string"
                             },
                             "armToolchainPath": {
@@ -1440,7 +1440,7 @@
                             },
                             "rtos": {
                                 "default": null,
-                                "description": "RTOS being used. For JLink this can be ChibiOS, embOS, FreeRTOS, NuttX, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be eCos, ThreadX, FreeRTOS, ChibiOS, embKernel, mqx, uCOS-III, nuttx or auto.",
+                                "description": "RTOS being used. For JLink this can be Azure, ChibiOS, embOS, FreeRTOS, NuttX, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be ChibiOS, eCos, embKernel, FreeRTOS, mqx, nuttx, ThreadX, uCOS-III, or auto.",
                                 "type": "string"
                             },
                             "armToolchainPath": {

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -6,8 +6,8 @@ import { GDBServerConsole } from './server_console';
 import { CortexDebugKeys } from '../common';
 import * as path from 'path';
 
-const OPENOCD_VALID_RTOS: string[] = ['eCos', 'ThreadX', 'FreeRTOS', 'ChibiOS', 'embKernel', 'mqx', 'uCOS-III', 'nuttx', 'auto'];
-const JLINK_VALID_RTOS: string[] = ['FreeRTOS', 'embOS', 'ChibiOS', 'Zephyr', 'NuttX'];
+const OPENOCD_VALID_RTOS: string[] = ['ChibiOS', 'eCos', 'embKernel', 'FreeRTOS', 'mqx', 'nuttx', 'ThreadX', 'uCOS-III', 'auto'];
+const JLINK_VALID_RTOS: string[] = ['Azure', 'ChibiOS', 'embOS', 'FreeRTOS', 'NuttX', 'Zephyr'];
 
 export class CortexDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
     constructor(private context: vscode.ExtensionContext) {}


### PR DESCRIPTION
Fixes #543 
Also resorted elements by name in package.json and code.

I didn't test the plugin itself, but got following lines from J-Link:
```
Loading RTOS plugin: GDBServer/RTOSPlugin_Azure.dll...
RTOS plugin (API v1.1) loaded successfully
RTOS plugin: Loaded
Received symbol: _tx_thread_current_ptr (0x00000000)
ERROR: Mandatory symbol _tx_thread_current_ptr not found.
```

So plugin should load as expected.

At least good enough for me 🎉 
