### PR TITLE
Pass accessType from field into PeripheralFieldNode

### DIFF
--- a/src/frontend/svd.ts
+++ b/src/frontend/svd.ts
@@ -175,13 +175,17 @@ export class SVDParser {
                 }
             }
 
-            const baseOptions = {
+            const baseOptions: any = {
                 name: f.name[0],
                 description: description,
                 offset: offset,
                 width: width,
                 enumeration: valueMap
             };
+
+            if (f.access) {
+                baseOptions.accessType = ACCESS_TYPE_MAP[f.access[0]];
+            }
 
             if (f.dim) {
                 if (!f.dimIncrement) { throw new Error(`Unable to parse SVD file: field ${f.name[0]} has dim element, with no dimIncrement element.`); }

--- a/src/frontend/views/nodes/peripheralfieldnode.ts
+++ b/src/frontend/views/nodes/peripheralfieldnode.ts
@@ -146,7 +146,7 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
             }
 
             mds.appendMarkdown(`| ${ ev } &nbsp;&nbsp; | ${ hex } &nbsp;&nbsp; | ${ decimal } &nbsp;&nbsp; | ${ binary } &nbsp;&nbsp; |\n\n`);
-            if (this.enumeration[value].description) {
+            if (this.enumeration[value] && this.enumeration[value].description) {
                 mds.appendMarkdown(this.enumeration[value].description);
             }
         } else {


### PR DESCRIPTION
Hi there, 

we realized that for our SVD file the Cortex Peripherals tab could not create proper Tooltips and some could not be expanded because of an error.

It seems like the accessType was not passed over for fields.

This change works for us but is untested for other use cases!
 - Tooltips now show specific registers as (write-only).
 - Expanding Registers and Write to write-only fields also works

Please feel free to check and merge our PR.

Martin