### PR TITLE
Added short delay (250ms) between target-disconnect and gdb-exit

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -393,6 +393,7 @@ export class MI2 extends EventEmitter implements IBackend {
             // program is in paused state
             try {
                 await this.sendCommand('target-disconnect');
+                await new Promise(f => setTimeout(f, 250));
                 this.sendRaw('-gdb-exit');
             }
             catch (e) {


### PR DESCRIPTION
This at (least for me) solves #629 
However I am by no means a TypeScript developer and have no idea if the delay should be implemented like this.
Feel free to improve @haneefdm 