### PR TITLE
backend/disasm.ts: fix typo: instrunctions -> instructions

### DIFF
--- a/src/backend/disasm.ts
+++ b/src/backend/disasm.ts
@@ -487,7 +487,7 @@ export class GdbDisassembler {
         }
         if (this.doTiming) {
             const total = srcCount + asmCount;
-            this.handleMsg('stdout', `Debug: ${cmd} => Found ${total} instrunctions. ${srcCount} with source code, ${asmCount} without\n`);
+            this.handleMsg('stdout', `Debug: ${cmd} => Found ${total} instructions. ${srcCount} with source code, ${asmCount} without\n`);
         }
         return new DisassemblyReturn(instructions, foundIx, false);
     }


### PR DESCRIPTION
Tiny typo fix. Looks great so far, I'm using it with an XDS110 instead of code composer studio, which I find buggy on linux (fedora 36). Thanks for all the hard work!