### PR TITLE
Return memory references from evaluate requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ChangeLog
 ## New features
 * RTOS View for uC/OS-II. Added by @PhilippHaefele & @mayjs via PR [#642](https://github.com/Marus/cortex-debug/pull/642) 
 * Better error handling during RTOS initial queries
+* Memory references are returned from DAP evaluate requests. PR [#694](https://github.com/Marus/cortex-debug/pull/694)
 
 # V1.5.1
 ## New features

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -135,12 +135,29 @@ export class VariableObject {
             },
             variablesReference: this.id
         };
-        if ((this.numchild > 0) && this.value.startsWith('0x')) {
-            res.memoryReference = hexFormat(parseInt(this.value));
-        }
+        this.tryAddMemoryReference(res);
 
         res.type = this.createToolTip(res.name, res.value);      // This ends up becoming a tool-tip
         return res;
+    }
+
+    public toProtocolEvaluateResponseBody(): DebugProtocol.EvaluateResponse['body'] {
+        const res: DebugProtocol.EvaluateResponse['body'] = {
+            result: this.value,
+            type: this.type,
+            presentationHint: {
+                kind: this.displayhint
+            },
+            variablesReference: this.id,
+        };
+        this.tryAddMemoryReference(res);
+        return res;
+    }
+
+    private tryAddMemoryReference(result: object): void {
+        if ((this.numchild > 0) && this.value.startsWith('0x')) {
+            result['memoryReference'] = hexFormat(parseInt(this.value));
+        }
     }
 }
 

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -3211,14 +3211,7 @@ export class GDBDebugSession extends LoggingDebugSession {
                             }
                         }
 
-                        response.body = {
-                            result: varObj.value,
-                            type: varObj.type,
-                            presentationHint: {
-                                kind: varObj.displayhint
-                            },
-                            variablesReference: varObj.id
-                        };
+                        response.body = varObj.toProtocolEvaluateResponseBody();
                         this.sendResponse(response);
                     }
                     catch (err) {


### PR DESCRIPTION
This functionality is needed to support https://github.com/microsoft/vscode-embedded-tools/issues/3.

Per the DAP spec Embedded Tools treats `memoryReference` values as opaque. This means in order to issue a `readMemory` request, we must first get a memory reference from an `evaluate` or `variables` request. However, Cortex-Debug does not currently return a `memoryReference` from an `evaluate` request, making it difficult or impossible to read some values from memory without directly constructing the `memoryReference`.

@robotdad @gcampbell FYI