### PR TITLE
Support channels 1-15 for JLink RTT

### DIFF
--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -420,12 +420,18 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
         }
 
         if (config.rttConfig && config.rttConfig.enabled && config.rttConfig.decoders && (config.rttConfig.decoders.length !== 0)) {
+            var chosenPort = undefined;
             for (const dec of config.rttConfig.decoders) {
                 if (dec.port === undefined) {
                     dec.port = 0;
-                } else if (dec.port !== 0) {
-                    return `Invalid port/channel '${dec.port}'. JLink RTT port/channel has to be 0 because that is the only one supported by JLinkGDBServer`;
+                } else if (dec.port < 0 || dec.port > 15) {
+                    return `Invalid port/channel '${dec.port}'.  JLink RTT port/channel must be between 0 and 15.`
                 }
+
+                if (chosenPort !== undefined && chosenPort !== dec.port) {
+                    return `Port/channel ${dec.port} selected but another decoder is using port ${chosenPort}.  JLink RTT only allows a single RTT port/channel per debugging session.`
+                }
+                chosenPort = dec.port;
             }
         }
 

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -14,7 +14,7 @@ import { MemoryContentProvider } from './memory_content_provider';
 import Reporting from '../reporting';
 
 import { CortexDebugConfigurationProvider } from './configprovider';
-import { SocketRTTSource, SocketSWOSource } from './swo/sources/socket';
+import { JLinkSocketRTTSource, SocketRTTSource, SocketSWOSource } from './swo/sources/socket';
 import { FifoSWOSource } from './swo/sources/fifo';
 import { FileSWOSource } from './swo/sources/file';
 import { SerialSWOSource } from './swo/sources/serial';
@@ -975,7 +975,11 @@ export class CortexDebugExtension {
                 resolve(src);
                 return;
             }
-            src = new SocketRTTSource(tcpPort, channel);
+            if (mySession.config.servertype === 'jlink') {
+                src = new JLinkSocketRTTSource(tcpPort, channel);
+            } else {
+                src = new SocketRTTSource(tcpPort, channel);
+            }
             mySession.rttPortMap[channel] = src;     // Yes, we put this in the list even if start() can fail
             resolve(src);                       // Yes, it is okay to resolve it even though the connection isn't made yet
             src.start().then(() => {

--- a/src/frontend/swo/sources/socket.ts
+++ b/src/frontend/swo/sources/socket.ts
@@ -119,3 +119,17 @@ export class SocketRTTSource extends SocketSWOSource {
         }
     }
 }
+
+export class JLinkSocketRTTSource extends SocketRTTSource {
+    constructor(tcpPort: string, public readonly channel: number) {
+        super(tcpPort, channel);
+
+        // When the TCP connection to the RTT port is established, send config commands
+        // within 100ms to configure the RTT channel.  See
+        // https://wiki.segger.com/RTT#SEGGER_TELNET_Config_String for more information
+        // on the config string format.
+        this.on('connected', () => {
+            this.write(`$$SEGGER_TELNET_ConfigStr=RTTCh;${channel}$$`);
+        });
+    }
+}


### PR DESCRIPTION
* JLinkGDBServer supports setting the RTT channel number via control
  commands set within the first 100ms of established TCP connection.

* JLinkGDBServer does not allow multiple concurrent TCP connections to
  the same TCP RTT port so we are still blocked from running multiple
  RTT channels concurrently.

I validated these changes by attaching a debug session to an RTT-enabled MCU that outputs logs on RTT channel 2.  Before these changes, input validation instructed me to change RTT channel to 0.  After removing input validation, the RTT terminal didn't show up.  After putting in the full RTT configuration implementation, application logs started streaming to the debug terminal as expected.

Tagging @haneefdm since it looks like they most recently contributed to RTT-related work.