### PR TITLE
Apply Fixes to tslint Failures

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -148,7 +148,7 @@ export class VariableObject {
             presentationHint: {
                 kind: this.displayhint
             },
-            variablesReference: this.id,
+            variablesReference: this.id
         };
         this.tryAddMemoryReference(res);
         return res;

--- a/src/frontend/rtos/rtos.ts
+++ b/src/frontend/rtos/rtos.ts
@@ -340,7 +340,7 @@ export class RTOSTracker
                     ret.html += `<p>Failed to match any supported RTOS. Supported RTOSes are (${supported}). ` +
                         'Please report issues and/or contribute code/knowledge to add your RTOS</p>\n';
                 } else {
-                    ret.html += /*html*/`<p>Try refreshing this panel. RTOS detection may be still in progress</p>\n`;
+                    ret.html += /*html*/'<p>Try refreshing this panel. RTOS detection may be still in progress</p>\n';
                 }
             } else {
                 const nameAndStatus = name + ', ' + rtosSession.rtos.name + ' detected.' + (!rtosSession.htmlContent ? ' (No data available yet)' : '');

--- a/src/frontend/swo/sources/file.ts
+++ b/src/frontend/swo/sources/file.ts
@@ -34,7 +34,7 @@ export class FileSWOSource extends EventEmitter implements SWORTTSource {
                 if (delta >= timeout) {
                     vscode.window.showWarningMessage(`SWO File ${SWOPath} does not exist even after timeout of ${timeout}ms.`);
                 } else {
-                    setTimeout(openFile, Math.min(10, retryTime+1));
+                    setTimeout(openFile, Math.min(10, retryTime + 1));
                 }
             }
         }

--- a/src/frontend/views/nodes/fieldnode.ts
+++ b/src/frontend/views/nodes/fieldnode.ts
@@ -5,7 +5,7 @@ import { toStringDecHexOctBin } from '../../../common';
 
 export class FieldNode extends BaseNode {
     public prevValue: string = '';
-    public value: string = ''
+    public value: string = '';
     
     constructor(public name: string, private offset: number, private size: number, private register: RegisterNode) {
         super(register);
@@ -21,7 +21,7 @@ export class FieldNode extends BaseNode {
 
         const label: TreeItemLabel = {
             label: this.name + ' ' + this.value
-        }
+        };
         if (this.prevValue && (this.prevValue !== this.value)) {
             label.highlights = [[this.name.length + 1, label.label.length]];
         }

--- a/src/frontend/views/nodes/peripheralregisternode.ts
+++ b/src/frontend/views/nodes/peripheralregisternode.ts
@@ -140,7 +140,8 @@ export class PeripheralRegisterNode extends PeripheralBaseNode {
         mds.appendMarkdown('|:---|:---:|:---|:---|\n');
 
         children.forEach((field) => {
-            mds.appendMarkdown(`| ${ field.name } | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | ${ field.getFormattedRange() } | ${ field.getFormattedValue(field.getFormat(), true) } |\n`);
+            mds.appendMarkdown(`| ${ field.name } | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | ${ field.getFormattedRange() } | `
+                + `${ field.getFormattedValue(field.getFormat(), true) } |\n`);
         });
 
         return mds;

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -3,21 +3,21 @@ import * as path from 'path';
 import { runTests } from '@vscode/test-electron';
 
 async function main() {
-	try {
-		// The folder containing the Extension Manifest package.json
-		// Passed to `--extensionDevelopmentPath`
-		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+    try {
+        // The folder containing the Extension Manifest package.json
+        // Passed to `--extensionDevelopmentPath`
+        const extensionDevelopmentPath = path.resolve(__dirname, '../../');
 
-		// The path to the extension test script
-		// Passed to --extensionTestsPath
-		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+        // The path to the extension test script
+        // Passed to --extensionTestsPath
+        const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
-		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
-	} catch (err) {
-		console.error('Failed to run tests');
-		process.exit(1);
-	}
+        // Download VS Code, unzip it and run the integration test
+        await runTests({ extensionDevelopmentPath, extensionTestsPath });
+    } catch (err) {
+        console.error('Failed to run tests');
+        process.exit(1);
+    }
 }
 
 main();

--- a/test/suite/gdb_expansion.test.ts
+++ b/test/suite/gdb_expansion.test.ts
@@ -1,295 +1,298 @@
 import * as assert from 'assert';
 import { expandValue, isExpandable } from '../../src/backend/gdb_expansion';
 
-suite("GDB Value Expansion", () => {
-	let variableCreate = (variable) => { return { expanded: variable }; };
-	test("Various values", () => {
-		assert.strictEqual(isExpandable(`false`), 0);
-		assert.equal(expandValue(variableCreate, `false`), "false");
-		assert.strictEqual(isExpandable(`5`), 0);
-		assert.equal(expandValue(variableCreate, `5`), "5");
-		assert.strictEqual(isExpandable(`"hello world!"`), 0);
-		assert.equal(expandValue(variableCreate, `"hello world!"`), `"hello world!"`);
-		assert.strictEqual(isExpandable(`0x7fffffffe956 "foobar"`), 0);
-		assert.equal(expandValue(variableCreate, `0x7fffffffe956 "foobar"`), `"foobar"`);
-		assert.strictEqual(isExpandable(`0x0`), 0);
-		assert.equal(expandValue(variableCreate, `0x0`), "<nullptr>");
-		assert.strictEqual(isExpandable(`0x000000`), 0);
-		assert.equal(expandValue(variableCreate, `0x000000`), "<nullptr>");
-		assert.strictEqual(isExpandable(`{...}`), 2);
-		assert.equal(expandValue(variableCreate, `{...}`), "<...>");
-		assert.strictEqual(isExpandable(`0x00abc`), 2);
-		assert.equal(expandValue(variableCreate, `0x007ffff7ecb480`), "*0x007ffff7ecb480");
-		assert.strictEqual(isExpandable(`{a = b, c = d}`), 1);
-		assert.deepEqual(expandValue(variableCreate, `{a = b, c = d}`), [
-			{
-				name: "a",
-				value: "b",
-				variablesReference: 0
-			}, {
-				name: "c",
-				value: "d",
-				variablesReference: 0
-			}]);
-		assert.strictEqual(isExpandable(`{[0] = 0x400730 "foo", [1] = 0x400735 "bar"}`), 1);
-		assert.deepEqual(expandValue(variableCreate, `{[0] = 0x400730 "foo", [1] = 0x400735 "bar"}`), [
-			{
-				name: "[0]",
-				value: "\"foo\"",
-				variablesReference: 0
-			}, {
-				name: "[1]",
-				value: "\"bar\"",
-				variablesReference: 0
-			}]);
-		assert.strictEqual(isExpandable(`{{a = b}}`), 1);
-		assert.deepEqual(expandValue(variableCreate, `{{a = b}}`), [
-			{
-				name: "[0]",
-				value: "Object",
-				variablesReference: {
-					expanded: [
-						{
-							name: "a",
-							value: "b",
-							variablesReference: 0
-						}
-					]
-				}
-			}
-		]);
-		assert.deepEqual(expandValue(variableCreate, `{1, 2, 3, 4}`), [
-			{
-				name: "[0]",
-				value: "1",
-				variablesReference: 0
-			}, {
-				name: "[1]",
-				value: "2",
-				variablesReference: 0
-			}, {
-				name: "[2]",
-				value: "3",
-				variablesReference: 0
-			}, {
-				name: "[3]",
-				value: "4",
-				variablesReference: 0
-			}]);
-	});
-	test("Error values", () => {
-		assert.strictEqual(isExpandable(`<No data fields>`), 0);
-		assert.equal(expandValue(variableCreate, `<No data fields>`), "<No data fields>");
-	});
-	test("Nested values", () => {
-		assert.strictEqual(isExpandable(`{a = {b = e}, c = d}`), 1);
-		assert.deepEqual(expandValue(variableCreate, `{a = {b = e}, c = d}`), [
-			{
-				name: "a",
-				value: "Object",
-				variablesReference: {
-					expanded: [
-						{
-							name: "b",
-							value: "e",
-							variablesReference: 0
-						}
-					]
-				}
-			}, {
-				name: "c",
-				value: "d",
-				variablesReference: 0
-			}]);
-	});
-	test("Simple node", () => {
-		assert.strictEqual(isExpandable(`{a = false, b = 5, c = 0x0, d = "foobar"}`), 1);
-		let variables = expandValue(variableCreate, `{a = false, b = 5, c = 0x0, d = "foobar"}`);
-		assert.equal(variables.length, 4);
-		assert.equal(variables[0].name, "a");
-		assert.equal(variables[0].value, "false");
-		assert.equal(variables[1].name, "b");
-		assert.equal(variables[1].value, "5");
-		assert.equal(variables[2].name, "c");
-		assert.equal(variables[2].value, "<nullptr>");
-		assert.equal(variables[3].name, "d");
-		assert.equal(variables[3].value, `"foobar"`);
-	});
-	test("Complex node", () => {
-		let node = `{quit = false, _views = {{view = 0x7ffff7ece1e8, renderer = 0x7ffff7eccc50, world = 0x7ffff7ece480}}, deltaTimer = {_flagStarted = false, _timeStart = {length = 0}, _timeMeasured = {length = 0}}, _start = {callbacks = 0x0}, _stop = {callbacks = 0x0}}`;
-		assert.strictEqual(isExpandable(node), 1);
-		let variables = expandValue(variableCreate, node);
-		assert.deepEqual(variables, [
-			{
-				name: "quit",
-				value: "false",
-				variablesReference: 0
-			},
-			{
-				name: "_views",
-				value: "Object",
-				variablesReference: {
-					expanded: [
-						{
-							name: "[0]",
-							value: "Object",
-							variablesReference: {
-								expanded: [
-									{
-										name: "view",
-										value: "Object@*0x7ffff7ece1e8",
-										variablesReference: { expanded: "*_views[0].view" }
-									},
-									{
-										name: "renderer",
-										value: "Object@*0x7ffff7eccc50",
-										variablesReference: { expanded: "*_views[0].renderer" }
-									},
-									{
-										name: "world",
-										value: "Object@*0x7ffff7ece480",
-										variablesReference: { expanded: "*_views[0].world" }
-									}
-								]
-							}
-						}
-					]
-				}
-			},
-			{
-				name: "deltaTimer",
-				value: "Object",
-				variablesReference: {
-					expanded: [
-						{
-							name: "_flagStarted",
-							value: "false",
-							variablesReference: 0
-						},
-						{
-							name: "_timeStart",
-							value: "Object",
-							variablesReference: {
-								expanded: [
-									{
-										name: "length",
-										value: "0",
-										variablesReference: 0
-									}
-								]
-							}
-						},
-						{
-							name: "_timeMeasured",
-							value: "Object",
-							variablesReference: {
-								expanded: [
-									{
-										name: "length",
-										value: "0",
-										variablesReference: 0
-									}
-								]
-							}
-						}
-					]
-				}
-			},
-			{
-				name: "_start",
-				value: "Object",
-				variablesReference: {
-					expanded: [
-						{
-							name: "callbacks",
-							value: "<nullptr>",
-							variablesReference: 0
-						}
-					]
-				}
-			},
-			{
-				name: "_stop",
-				value: "Object",
-				variablesReference: {
-					expanded: [
-						{
-							name: "callbacks",
-							value: "<nullptr>",
-							variablesReference: 0
-						}
-					]
-				}
-			}
-		]);
-	});
-	test("Simple node with errors", () => {
-		let node = `{_enableMipMaps = false, _minFilter = <incomplete type>, _magFilter = <incomplete type>, _wrapX = <incomplete type>, _wrapY = <incomplete type>, _inMode = 6408, _mode = 6408, _id = 1, _width = 1024, _height = 1024}`;
-		assert.strictEqual(isExpandable(node), 1);
-		let variables = expandValue(variableCreate, node);
-		assert.deepEqual(variables, [
-			{
-				name: "_enableMipMaps",
-				value: "false",
-				variablesReference: 0
-			},
-			{
-				name: "_minFilter",
-				value: "<incomplete type>",
-				variablesReference: 0
-			},
-			{
-				name: "_magFilter",
-				value: "<incomplete type>",
-				variablesReference: 0
-			},
-			{
-				name: "_wrapX",
-				value: "<incomplete type>",
-				variablesReference: 0
-			},
-			{
-				name: "_wrapY",
-				value: "<incomplete type>",
-				variablesReference: 0
-			},
-			{
-				name: "_inMode",
-				value: "6408",
-				variablesReference: 0
-			},
-			{
-				name: "_mode",
-				value: "6408",
-				variablesReference: 0
-			},
-			{
-				name: "_id",
-				value: "1",
-				variablesReference: 0
-			},
-			{
-				name: "_width",
-				value: "1024",
-				variablesReference: 0
-			},
-			{
-				name: "_height",
-				value: "1024",
-				variablesReference: 0
-			}
-		]);
-	});
-	test("lldb strings", () => {
-		let node = `{ name = {...} }`;
-		assert.strictEqual(isExpandable(node), 1);
-		let variables = expandValue(variableCreate, node);
-		assert.deepEqual(variables, [
-			{
-				name: "name",
-				value: "...",
-				variablesReference: { expanded: "name" }
-			}
-		]);
-	});
+suite('GDB Value Expansion', () => {
+    const variableCreate = (variable) => ({ expanded: variable });
+    test('Various values', () => {
+        assert.strictEqual(isExpandable('false'), 0);
+        assert.equal(expandValue(variableCreate, 'false'), 'false');
+        assert.strictEqual(isExpandable('5'), 0);
+        assert.equal(expandValue(variableCreate, '5'), '5');
+        assert.strictEqual(isExpandable('"hello world!"'), 0);
+        assert.equal(expandValue(variableCreate, '"hello world!"'), '"hello world!"');
+        assert.strictEqual(isExpandable('0x7fffffffe956 "foobar"'), 0);
+        assert.equal(expandValue(variableCreate, '0x7fffffffe956 "foobar"'), '"foobar"');
+        assert.strictEqual(isExpandable('0x0'), 0);
+        assert.equal(expandValue(variableCreate, '0x0'), '<nullptr>');
+        assert.strictEqual(isExpandable('0x000000'), 0);
+        assert.equal(expandValue(variableCreate, '0x000000'), '<nullptr>');
+        assert.strictEqual(isExpandable('{...}'), 2);
+        assert.equal(expandValue(variableCreate, '{...}'), '<...>');
+        assert.strictEqual(isExpandable('0x00abc'), 2);
+        assert.equal(expandValue(variableCreate, '0x007ffff7ecb480'), '*0x007ffff7ecb480');
+        assert.strictEqual(isExpandable('{a = b, c = d}'), 1);
+        assert.deepEqual(expandValue(variableCreate, '{a = b, c = d}'), [
+            {
+                name: 'a',
+                value: 'b',
+                variablesReference: 0
+            }, {
+                name: 'c',
+                value: 'd',
+                variablesReference: 0
+            }]);
+        assert.strictEqual(isExpandable('{[0] = 0x400730 "foo", [1] = 0x400735 "bar"}'), 1);
+        assert.deepEqual(expandValue(variableCreate, '{[0] = 0x400730 "foo", [1] = 0x400735 "bar"}'), [
+            {
+                name: '[0]',
+                value: '"foo"',
+                variablesReference: 0
+            }, {
+                name: '[1]',
+                value: '"bar"',
+                variablesReference: 0
+            }]);
+        assert.strictEqual(isExpandable('{{a = b}}'), 1);
+        assert.deepEqual(expandValue(variableCreate, '{{a = b}}'), [
+            {
+                name: '[0]',
+                value: 'Object',
+                variablesReference: {
+                    expanded: [
+                        {
+                            name: 'a',
+                            value: 'b',
+                            variablesReference: 0
+                        }
+                    ]
+                }
+            }
+        ]);
+        assert.deepEqual(expandValue(variableCreate, '{1, 2, 3, 4}'), [
+            {
+                name: '[0]',
+                value: '1',
+                variablesReference: 0
+            }, {
+                name: '[1]',
+                value: '2',
+                variablesReference: 0
+            }, {
+                name: '[2]',
+                value: '3',
+                variablesReference: 0
+            }, {
+                name: '[3]',
+                value: '4',
+                variablesReference: 0
+            }]);
+    });
+    test('Error values', () => {
+        assert.strictEqual(isExpandable('<No data fields>'), 0);
+        assert.equal(expandValue(variableCreate, '<No data fields>'), '<No data fields>');
+    });
+    test('Nested values', () => {
+        assert.strictEqual(isExpandable('{a = {b = e}, c = d}'), 1);
+        assert.deepEqual(expandValue(variableCreate, '{a = {b = e}, c = d}'), [
+            {
+                name: 'a',
+                value: 'Object',
+                variablesReference: {
+                    expanded: [
+                        {
+                            name: 'b',
+                            value: 'e',
+                            variablesReference: 0
+                        }
+                    ]
+                }
+            }, {
+                name: 'c',
+                value: 'd',
+                variablesReference: 0
+            }]);
+    });
+    test('Simple node', () => {
+        assert.strictEqual(isExpandable('{a = false, b = 5, c = 0x0, d = "foobar"}'), 1);
+        const variables = expandValue(variableCreate, '{a = false, b = 5, c = 0x0, d = "foobar"}');
+        assert.equal(variables.length, 4);
+        assert.equal(variables[0].name, 'a');
+        assert.equal(variables[0].value, 'false');
+        assert.equal(variables[1].name, 'b');
+        assert.equal(variables[1].value, '5');
+        assert.equal(variables[2].name, 'c');
+        assert.equal(variables[2].value, '<nullptr>');
+        assert.equal(variables[3].name, 'd');
+        assert.equal(variables[3].value, '"foobar"');
+    });
+    test('Complex node', () => {
+        const node = '{quit = false, _views = {{view = 0x7ffff7ece1e8, renderer = 0x7ffff7eccc50, world = 0x7ffff7ece480}}'
+            + 'deltaTimer = {_flagStarted = false, _timeStart = {length = 0}, _timeMeasured = {length = 0}}, _start = {callbacks = 0x0}, '
+            + '_stop = {callbacks = 0x0}}';
+        assert.strictEqual(isExpandable(node), 1);
+        const variables = expandValue(variableCreate, node);
+        assert.deepEqual(variables, [
+            {
+                name: 'quit',
+                value: 'false',
+                variablesReference: 0
+            },
+            {
+                name: '_views',
+                value: 'Object',
+                variablesReference: {
+                    expanded: [
+                        {
+                            name: '[0]',
+                            value: 'Object',
+                            variablesReference: {
+                                expanded: [
+                                    {
+                                        name: 'view',
+                                        value: 'Object@*0x7ffff7ece1e8',
+                                        variablesReference: { expanded: '*_views[0].view' }
+                                    },
+                                    {
+                                        name: 'renderer',
+                                        value: 'Object@*0x7ffff7eccc50',
+                                        variablesReference: { expanded: '*_views[0].renderer' }
+                                    },
+                                    {
+                                        name: 'world',
+                                        value: 'Object@*0x7ffff7ece480',
+                                        variablesReference: { expanded: '*_views[0].world' }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                name: 'deltaTimer',
+                value: 'Object',
+                variablesReference: {
+                    expanded: [
+                        {
+                            name: '_flagStarted',
+                            value: 'false',
+                            variablesReference: 0
+                        },
+                        {
+                            name: '_timeStart',
+                            value: 'Object',
+                            variablesReference: {
+                                expanded: [
+                                    {
+                                        name: 'length',
+                                        value: '0',
+                                        variablesReference: 0
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            name: '_timeMeasured',
+                            value: 'Object',
+                            variablesReference: {
+                                expanded: [
+                                    {
+                                        name: 'length',
+                                        value: '0',
+                                        variablesReference: 0
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                name: '_start',
+                value: 'Object',
+                variablesReference: {
+                    expanded: [
+                        {
+                            name: 'callbacks',
+                            value: '<nullptr>',
+                            variablesReference: 0
+                        }
+                    ]
+                }
+            },
+            {
+                name: '_stop',
+                value: 'Object',
+                variablesReference: {
+                    expanded: [
+                        {
+                            name: 'callbacks',
+                            value: '<nullptr>',
+                            variablesReference: 0
+                        }
+                    ]
+                }
+            }
+        ]);
+    });
+    test('Simple node with errors', () => {
+        const node = '{_enableMipMaps = false, _minFilter = <incomplete type>, _magFilter = <incomplete type>, _wrapX = <incomplete type>, '
+            + '_wrapY = <incomplete type>, _inMode = 6408, _mode = 6408, _id = 1, _width = 1024, _height = 1024}';
+        assert.strictEqual(isExpandable(node), 1);
+        const variables = expandValue(variableCreate, node);
+        assert.deepEqual(variables, [
+            {
+                name: '_enableMipMaps',
+                value: 'false',
+                variablesReference: 0
+            },
+            {
+                name: '_minFilter',
+                value: '<incomplete type>',
+                variablesReference: 0
+            },
+            {
+                name: '_magFilter',
+                value: '<incomplete type>',
+                variablesReference: 0
+            },
+            {
+                name: '_wrapX',
+                value: '<incomplete type>',
+                variablesReference: 0
+            },
+            {
+                name: '_wrapY',
+                value: '<incomplete type>',
+                variablesReference: 0
+            },
+            {
+                name: '_inMode',
+                value: '6408',
+                variablesReference: 0
+            },
+            {
+                name: '_mode',
+                value: '6408',
+                variablesReference: 0
+            },
+            {
+                name: '_id',
+                value: '1',
+                variablesReference: 0
+            },
+            {
+                name: '_width',
+                value: '1024',
+                variablesReference: 0
+            },
+            {
+                name: '_height',
+                value: '1024',
+                variablesReference: 0
+            }
+        ]);
+    });
+    test('lldb strings', () => {
+        const node = '{ name = {...} }';
+        assert.strictEqual(isExpandable(node), 1);
+        const variables = expandValue(variableCreate, node);
+        assert.deepEqual(variables, [
+            {
+                name: 'name',
+                value: '...',
+                variablesReference: { expanded: 'name' }
+            }
+        ]);
+    });
 });

--- a/test/suite/index.ts
+++ b/test/suite/index.ts
@@ -18,11 +18,11 @@ export function run(): Promise<void> {
             }
 
             // Add files to the test suite
-            files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+            files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
 
             try {
                 // Run the mocha test
-                mocha.run(failures => {
+                mocha.run((failures) => {
                     if (failures > 0) {
                         e(new Error(`${failures} tests failed.`));
                     } else {

--- a/test/suite/mi_parse.test.ts
+++ b/test/suite/mi_parse.test.ts
@@ -1,176 +1,180 @@
 import * as assert from 'assert';
 import { parseMI, MINode } from '../../src/backend/mi_parse';
 
-suite("MI Parse", () => {
-	test("Simple out of band record", () => {
-		let parsed = parseMI(`4=thread-exited,id="3",group-id="i1"`);
-		assert.ok(parsed);
-		assert.equal(parsed.token, 4);
-		assert.equal(parsed.outOfBandRecord.length, 1);
-		assert.equal(parsed.outOfBandRecord[0].isStream, false);
-		assert.equal(parsed.outOfBandRecord[0].asyncClass, "thread-exited");
-		assert.equal(parsed.outOfBandRecord[0].output.length, 2);
-		assert.deepEqual(parsed.outOfBandRecord[0].output[0], ["id", "3"]);
-		assert.deepEqual(parsed.outOfBandRecord[0].output[1], ["group-id", "i1"]);
-		assert.equal(parsed.resultRecords, undefined);
-	});
-	test("Console stream output with new line", () => {
-		let parsed = parseMI(`~"[Thread 0x7fffe993a700 (LWP 11002) exited]\\n"`);
-		assert.ok(parsed);
-		assert.equal(parsed.token, undefined);
-		assert.equal(parsed.outOfBandRecord.length, 1);
-		assert.equal(parsed.outOfBandRecord[0].isStream, true);
-		assert.equal(parsed.outOfBandRecord[0].content, "[Thread 0x7fffe993a700 (LWP 11002) exited]\n");
-		assert.equal(parsed.resultRecords, undefined);
-	});
-	test("Unicode", () => {
-		let parsed = parseMI(`~"[Depuraci\\303\\263n de hilo usando libthread_db enabled]\\n"`);
-		assert.ok(parsed);
-		assert.equal(parsed.token, undefined);
-		assert.equal(parsed.outOfBandRecord.length, 1);
-		assert.equal(parsed.outOfBandRecord[0].isStream, true);
-		assert.equal(parsed.outOfBandRecord[0].content, "[Depuración de hilo usando libthread_db enabled]\n");
-		assert.equal(parsed.resultRecords, undefined);
-		parsed = parseMI(`~"4\\t  std::cout << \\"\\345\\245\\275\\345\\245\\275\\345\\255\\246\\344\\271\\240\\357\\274\\214\\345\\244\\251\\345\\244\\251\\345\\220\\221\\344\\270\\212\\" << std::endl;\\n"`);
-		assert.ok(parsed);
-		assert.equal(parsed.token, undefined);
-		assert.equal(parsed.outOfBandRecord.length, 1);
-		assert.equal(parsed.outOfBandRecord[0].isStream, true);
-		assert.equal(parsed.outOfBandRecord[0].content, `4\t  std::cout << "好好学习，天天向上" << std::endl;\n`);
-		assert.equal(parsed.resultRecords, undefined);
-	});
-	test("Empty line", () => {
-		let parsed = parseMI(``);
-		assert.ok(parsed);
-		assert.equal(parsed.token, undefined);
-		assert.equal(parsed.outOfBandRecord.length, 0);
-		assert.equal(parsed.resultRecords, undefined);
-	});
-	test("'(gdb)' line", () => {
-		let parsed = parseMI(`(gdb)`);
-		assert.ok(parsed);
-		assert.equal(parsed.token, undefined);
-		assert.equal(parsed.outOfBandRecord.length, 0);
-		assert.equal(parsed.resultRecords, undefined);
-	});
-	test("Simple result record", () => {
-		let parsed = parseMI(`1^running`);
-		assert.ok(parsed);
-		assert.equal(parsed.token, 1);
-		assert.equal(parsed.outOfBandRecord.length, 0);
-		assert.notEqual(parsed.resultRecords, undefined);
-		assert.equal(parsed.resultRecords.resultClass, "running");
-		assert.equal(parsed.resultRecords.results.length, 0);
-	});
-	test("Advanced out of band record (Breakpoint hit)", () => {
-		let parsed = parseMI(`*stopped,reason="breakpoint-hit",disp="keep",bkptno="1",frame={addr="0x00000000004e807f",func="D main",args=[{name="args",value="..."}],file="source/app.d",fullname="/path/to/source/app.d",line="157"},thread-id="1",stopped-threads="all",core="0"`);
-		assert.ok(parsed);
-		assert.equal(parsed.token, undefined);
-		assert.equal(parsed.outOfBandRecord.length, 1);
-		assert.equal(parsed.outOfBandRecord[0].isStream, false);
-		assert.equal(parsed.outOfBandRecord[0].asyncClass, "stopped");
-		assert.equal(parsed.outOfBandRecord[0].output.length, 7);
-		assert.deepEqual(parsed.outOfBandRecord[0].output[0], ["reason", "breakpoint-hit"]);
-		assert.deepEqual(parsed.outOfBandRecord[0].output[1], ["disp", "keep"]);
-		assert.deepEqual(parsed.outOfBandRecord[0].output[2], ["bkptno", "1"]);
-		let frame = [
-			["addr", "0x00000000004e807f"],
-			["func", "D main"],
-			["args", [[["name", "args"], ["value", "..."]]]],
-			["file", "source/app.d"],
-			["fullname", "/path/to/source/app.d"],
-			["line", "157"]
-		];
-		assert.deepEqual(parsed.outOfBandRecord[0].output[3], ["frame", frame]);
-		assert.deepEqual(parsed.outOfBandRecord[0].output[4], ["thread-id", "1"]);
-		assert.deepEqual(parsed.outOfBandRecord[0].output[5], ["stopped-threads", "all"]);
-		assert.deepEqual(parsed.outOfBandRecord[0].output[6], ["core", "0"]);
-		assert.equal(parsed.resultRecords, undefined);
-	});
-	test("Advanced result record", () => {
-		let parsed = parseMI(`2^done,asm_insns=[src_and_asm_line={line="134",file="source/app.d",fullname="/path/to/source/app.d",line_asm_insn=[{address="0x00000000004e7da4",func-name="_Dmain",offset="0",inst="push   %rbp"},{address="0x00000000004e7da5",func-name="_Dmain",offset="1",inst="mov    %rsp,%rbp"}]}]`);
-		assert.ok(parsed);
-		assert.equal(parsed.token, 2);
-		assert.equal(parsed.outOfBandRecord.length, 0);
-		assert.notEqual(parsed.resultRecords, undefined);
-		assert.equal(parsed.resultRecords.resultClass, "done");
-		assert.equal(parsed.resultRecords.results.length, 1);
-		let asm_insns = [
-			"asm_insns",
-			[
-				[
-					"src_and_asm_line",
-					[
-						["line", "134"],
-						["file", "source/app.d"],
-						["fullname", "/path/to/source/app.d"],
-						[
-							"line_asm_insn",
-							[
-								[
-									["address", "0x00000000004e7da4"],
-									["func-name", "_Dmain"],
-									["offset", "0"],
-									["inst", "push   %rbp"]
-								],
-								[
-									["address", "0x00000000004e7da5"],
-									["func-name", "_Dmain"],
-									["offset", "1"],
-									["inst", "mov    %rsp,%rbp"]
-								]
-							]
-						]
-					]
-				]
-			]
-		];
-		assert.deepEqual(parsed.resultRecords.results[0], asm_insns);
-		assert.equal(parsed.result("asm_insns.src_and_asm_line.line_asm_insn[1].address"), "0x00000000004e7da5");
-	});
-	test("valueof children", () => {
-		let obj = [
-			[
-				"frame",
-				[
-					["level", "0"],
-					["addr", "0x0000000000435f70"],
-					["func", "D main"],
-					["file", "source/app.d"],
-					["fullname", "/path/to/source/app.d"],
-					["line", "5"]
-				]
-			],
-			[
-				"frame",
-				[
-					["level", "1"],
-					["addr", "0x00000000004372d3"],
-					["func", "rt.dmain2._d_run_main()"]
-				]
-			],
-			[
-				"frame",
-				[
-					["level", "2"],
-					["addr", "0x0000000000437229"],
-					["func", "rt.dmain2._d_run_main()"]
-				]
-			]
-		];
-		
-		assert.equal(MINode.valueOf(obj[0], "@frame.level"), "0");
-		assert.equal(MINode.valueOf(obj[0], "@frame.addr"), "0x0000000000435f70");
-		assert.equal(MINode.valueOf(obj[0], "@frame.func"), "D main");
-		assert.equal(MINode.valueOf(obj[0], "@frame.file"), "source/app.d");
-		assert.equal(MINode.valueOf(obj[0], "@frame.fullname"), "/path/to/source/app.d");
-		assert.equal(MINode.valueOf(obj[0], "@frame.line"), "5");
-		
-		assert.equal(MINode.valueOf(obj[1], "@frame.level"), "1");
-		assert.equal(MINode.valueOf(obj[1], "@frame.addr"), "0x00000000004372d3");
-		assert.equal(MINode.valueOf(obj[1], "@frame.func"), "rt.dmain2._d_run_main()");
-		assert.equal(MINode.valueOf(obj[1], "@frame.file"), undefined);
-		assert.equal(MINode.valueOf(obj[1], "@frame.fullname"), undefined);
-		assert.equal(MINode.valueOf(obj[1], "@frame.line"), undefined);
-	});
+suite('MI Parse', () => {
+    test('Simple out of band record', () => {
+        const parsed = parseMI('4=thread-exited,id="3",group-id="i1"');
+        assert.ok(parsed);
+        assert.equal(parsed.token, 4);
+        assert.equal(parsed.outOfBandRecord.length, 1);
+        assert.equal(parsed.outOfBandRecord[0].isStream, false);
+        assert.equal(parsed.outOfBandRecord[0].asyncClass, 'thread-exited');
+        assert.equal(parsed.outOfBandRecord[0].output.length, 2);
+        assert.deepEqual(parsed.outOfBandRecord[0].output[0], ['id', '3']);
+        assert.deepEqual(parsed.outOfBandRecord[0].output[1], ['group-id', 'i1']);
+        assert.equal(parsed.resultRecords, undefined);
+    });
+    test('Console stream output with new line', () => {
+        const parsed = parseMI('~"[Thread 0x7fffe993a700 (LWP 11002) exited]\\n"');
+        assert.ok(parsed);
+        assert.equal(parsed.token, undefined);
+        assert.equal(parsed.outOfBandRecord.length, 1);
+        assert.equal(parsed.outOfBandRecord[0].isStream, true);
+        assert.equal(parsed.outOfBandRecord[0].content, '[Thread 0x7fffe993a700 (LWP 11002) exited]\n');
+        assert.equal(parsed.resultRecords, undefined);
+    });
+    test('Unicode', () => {
+        let parsed = parseMI('~"[Depuraci\\303\\263n de hilo usando libthread_db enabled]\\n"');
+        assert.ok(parsed);
+        assert.equal(parsed.token, undefined);
+        assert.equal(parsed.outOfBandRecord.length, 1);
+        assert.equal(parsed.outOfBandRecord[0].isStream, true);
+        assert.equal(parsed.outOfBandRecord[0].content, '[Depuración de hilo usando libthread_db enabled]\n');
+        assert.equal(parsed.resultRecords, undefined);
+        parsed = parseMI('~"4\\t  std::cout << \\"\\345\\245\\275\\345\\245\\275\\345\\255\\246\\344\\271\\240\\357\\274\\214\\345\\244\\251\\345\\244\\251'
+            + '\\345\\220\\221\\344\\270\\212\\" << std::endl;\\n"');
+        assert.ok(parsed);
+        assert.equal(parsed.token, undefined);
+        assert.equal(parsed.outOfBandRecord.length, 1);
+        assert.equal(parsed.outOfBandRecord[0].isStream, true);
+        assert.equal(parsed.outOfBandRecord[0].content, '4\t  std::cout << "好好学习，天天向上" << std::endl;\n');
+        assert.equal(parsed.resultRecords, undefined);
+    });
+    test('Empty line', () => {
+        const parsed = parseMI('');
+        assert.ok(parsed);
+        assert.equal(parsed.token, undefined);
+        assert.equal(parsed.outOfBandRecord.length, 0);
+        assert.equal(parsed.resultRecords, undefined);
+    });
+    test('\'(gdb)\' line', () => {
+        const parsed = parseMI('(gdb)');
+        assert.ok(parsed);
+        assert.equal(parsed.token, undefined);
+        assert.equal(parsed.outOfBandRecord.length, 0);
+        assert.equal(parsed.resultRecords, undefined);
+    });
+    test('Simple result record', () => {
+        const parsed = parseMI('1^running');
+        assert.ok(parsed);
+        assert.equal(parsed.token, 1);
+        assert.equal(parsed.outOfBandRecord.length, 0);
+        assert.notEqual(parsed.resultRecords, undefined);
+        assert.equal(parsed.resultRecords.resultClass, 'running');
+        assert.equal(parsed.resultRecords.results.length, 0);
+    });
+    test('Advanced out of band record (Breakpoint hit)', () => {
+        const parsed = parseMI('*stopped,reason="breakpoint-hit",disp="keep",bkptno="1",frame={addr="0x00000000004e807f",func="D main",'
+            + 'args=[{name="args",value="..."}],file="source/app.d",fullname="/path/to/source/app.d",line="157"},thread-id="1",stopped-threads="all",core="0"');
+        assert.ok(parsed);
+        assert.equal(parsed.token, undefined);
+        assert.equal(parsed.outOfBandRecord.length, 1);
+        assert.equal(parsed.outOfBandRecord[0].isStream, false);
+        assert.equal(parsed.outOfBandRecord[0].asyncClass, 'stopped');
+        assert.equal(parsed.outOfBandRecord[0].output.length, 7);
+        assert.deepEqual(parsed.outOfBandRecord[0].output[0], ['reason', 'breakpoint-hit']);
+        assert.deepEqual(parsed.outOfBandRecord[0].output[1], ['disp', 'keep']);
+        assert.deepEqual(parsed.outOfBandRecord[0].output[2], ['bkptno', '1']);
+        const frame = [
+            ['addr', '0x00000000004e807f'],
+            ['func', 'D main'],
+            ['args', [[['name', 'args'], ['value', '...']]]],
+            ['file', 'source/app.d'],
+            ['fullname', '/path/to/source/app.d'],
+            ['line', '157']
+        ];
+        assert.deepEqual(parsed.outOfBandRecord[0].output[3], ['frame', frame]);
+        assert.deepEqual(parsed.outOfBandRecord[0].output[4], ['thread-id', '1']);
+        assert.deepEqual(parsed.outOfBandRecord[0].output[5], ['stopped-threads', 'all']);
+        assert.deepEqual(parsed.outOfBandRecord[0].output[6], ['core', '0']);
+        assert.equal(parsed.resultRecords, undefined);
+    });
+    test('Advanced result record', () => {
+        const parsed = parseMI('2^done,asm_insns=[src_and_asm_line={line="134",file="source/app.d",fullname="/path/to/source/app.d",'
+            + 'line_asm_insn=[{address="0x00000000004e7da4",func-name="_Dmain",offset="0",inst="push   %rbp"},'
+            + '{address="0x00000000004e7da5",func-name="_Dmain",offset="1",inst="mov    %rsp,%rbp"}]}]');
+        assert.ok(parsed);
+        assert.equal(parsed.token, 2);
+        assert.equal(parsed.outOfBandRecord.length, 0);
+        assert.notEqual(parsed.resultRecords, undefined);
+        assert.equal(parsed.resultRecords.resultClass, 'done');
+        assert.equal(parsed.resultRecords.results.length, 1);
+        const asmInsns = [
+            'asm_insns',
+            [
+                [
+                    'src_and_asm_line',
+                    [
+                        ['line', '134'],
+                        ['file', 'source/app.d'],
+                        ['fullname', '/path/to/source/app.d'],
+                        [
+                            'line_asm_insn',
+                            [
+                                [
+                                    ['address', '0x00000000004e7da4'],
+                                    ['func-name', '_Dmain'],
+                                    ['offset', '0'],
+                                    ['inst', 'push   %rbp']
+                                ],
+                                [
+                                    ['address', '0x00000000004e7da5'],
+                                    ['func-name', '_Dmain'],
+                                    ['offset', '1'],
+                                    ['inst', 'mov    %rsp,%rbp']
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        assert.deepEqual(parsed.resultRecords.results[0], asmInsns);
+        assert.equal(parsed.result('asm_insns.src_and_asm_line.line_asm_insn[1].address'), '0x00000000004e7da5');
+    });
+    test('valueof children', () => {
+        const obj = [
+            [
+                'frame',
+                [
+                    ['level', '0'],
+                    ['addr', '0x0000000000435f70'],
+                    ['func', 'D main'],
+                    ['file', 'source/app.d'],
+                    ['fullname', '/path/to/source/app.d'],
+                    ['line', '5']
+                ]
+            ],
+            [
+                'frame',
+                [
+                    ['level', '1'],
+                    ['addr', '0x00000000004372d3'],
+                    ['func', 'rt.dmain2._d_run_main()']
+                ]
+            ],
+            [
+                'frame',
+                [
+                    ['level', '2'],
+                    ['addr', '0x0000000000437229'],
+                    ['func', 'rt.dmain2._d_run_main()']
+                ]
+            ]
+        ];
+
+        assert.equal(MINode.valueOf(obj[0], '@frame.level'), '0');
+        assert.equal(MINode.valueOf(obj[0], '@frame.addr'), '0x0000000000435f70');
+        assert.equal(MINode.valueOf(obj[0], '@frame.func'), 'D main');
+        assert.equal(MINode.valueOf(obj[0], '@frame.file'), 'source/app.d');
+        assert.equal(MINode.valueOf(obj[0], '@frame.fullname'), '/path/to/source/app.d');
+        assert.equal(MINode.valueOf(obj[0], '@frame.line'), '5');
+
+        assert.equal(MINode.valueOf(obj[1], '@frame.level'), '1');
+        assert.equal(MINode.valueOf(obj[1], '@frame.addr'), '0x00000000004372d3');
+        assert.equal(MINode.valueOf(obj[1], '@frame.func'), 'rt.dmain2._d_run_main()');
+        assert.equal(MINode.valueOf(obj[1], '@frame.file'), undefined);
+        assert.equal(MINode.valueOf(obj[1], '@frame.fullname'), undefined);
+        assert.equal(MINode.valueOf(obj[1], '@frame.line'), undefined);
+    });
 });


### PR DESCRIPTION
I took the liberty of applying `tslint --fix` to the entire repository and fixing the remaining `tslint` failures.  I build and installed the plugin locally and have been using it for the past day and it looks ok.  Not sure if you would like more thorough validation before merging these changes.

Once this PR is in, I have another PR (#702) that creates a GitHub actions workflow to both build this project and run `tslint` to check for tslint compliance.