### PR TITLE
Add External JLink servertype.

### DIFF
--- a/package.json
+++ b/package.json
@@ -564,7 +564,7 @@
                         "properties": {
                             "servertype": {
                                 "type": "string",
-                                "description": "GDB Server type - supported types are jlink, openocd, pyocd, pe, stlink, stutil, qemu, bmp and external",
+                                "description": "GDB Server type - supported types are jlink, openocd, pyocd, pe, stlink, stutil, qemu, bmp, jlinkexternal and external",
                                 "enum": [
                                     "jlink",
                                     "openocd",
@@ -574,7 +574,8 @@
                                     "bmp",
                                     "pe",
                                     "qemu",
-                                    "external"
+                                    "external",
+                                    "jlinkexternal"
                                 ]
                             },
                             "cwd": {
@@ -1627,7 +1628,7 @@
                         "properties": {
                             "servertype": {
                                 "type": "string",
-                                "description": "GDB Server type - supported types are jlink, openocd, pyocd, pe, stlink, stutil, qemu, bmp and external",
+                                "description": "GDB Server type - supported types are jlink, openocd, pyocd, pe, stlink, stutil, qemu, bmp, jlinkexternal and external",
                                 "enum": [
                                     "jlink",
                                     "openocd",
@@ -1637,7 +1638,8 @@
                                     "bmp",
                                     "pe",
                                     "qemu",
-                                    "external"
+                                    "external",
+                                    "jlinkexternal"
                                 ]
                             },
                             "cwd": {

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -112,6 +112,7 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
                 validationResponse = this.verifyPEConfiguration(folder, config);
                 break;
             case 'external':
+            case 'jlinkexternal':
                 validationResponse = this.verifyExternalConfiguration(folder, config);
                 break;
             case 'qemu':

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -25,6 +25,7 @@ import { setTimeout } from 'timers';
 import { EventEmitter } from 'events';
 
 import { JLinkServerController } from './jlink';
+import { JLinkExternalServerController } from './jlinkexternal';
 import { OpenOCDServerController } from './openocd';
 import { STUtilServerController } from './stutil';
 import { STLinkServerController } from './stlink';
@@ -39,6 +40,7 @@ import { TcpPortScanner } from './tcpportscanner';
 
 const SERVER_TYPE_MAP = {
     jlink: JLinkServerController,
+    jlinkexternal: JLinkExternalServerController,
     openocd: OpenOCDServerController,
     stutil: STUtilServerController,
     stlink: STLinkServerController,

--- a/src/jlinkexternal.ts
+++ b/src/jlinkexternal.ts
@@ -1,0 +1,139 @@
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { ConfigurationArguments, GDBServerController, SWOConfigureEvent, calculatePortMask, genDownloadCommands } from './common';
+import * as os from 'os';
+import * as tmp from 'tmp';
+import { EventEmitter } from 'events';
+import * as ChildProcess from 'child_process';
+
+export class JLinkExternalServerController extends EventEmitter implements GDBServerController {
+    public readonly name: string = 'JLink External';
+    public readonly portsNeeded: string[] = [];
+    private swoPath: string;
+
+    private args: ConfigurationArguments;
+    private ports: { [name: string]: number };
+
+    constructor() {
+        super();
+        this.swoPath = tmp.tmpNameSync();
+    }
+
+    public setPorts(ports: { [name: string]: number }): void {
+        this.ports = ports;
+    }
+
+    public setArguments(args: ConfigurationArguments): void {
+        this.args = args;
+        if (this.args.swoConfig.enabled) {
+            if (os.platform() === 'win32') {
+                this.swoPath = this.swoPath.replace(/\\/g, '/');
+            }
+        }
+    }
+
+    public customRequest(command: string, response: DebugProtocol.Response, args: any): boolean {
+        return false;
+    }
+
+    public initCommands(): string[] {
+        const target = this.args.gdbTarget;
+        return [
+            `target-select extended-remote ${target}`
+        ];
+    }
+
+    public launchCommands(): string[] {
+        const commands = [
+            'interpreter-exec console "monitor halt"',
+            ...genDownloadCommands(this.args, ['interpreter-exec console "monitor reset"']),
+            'interpreter-exec console "monitor reset"'
+        ];
+
+        return commands;
+    }
+
+    public attachCommands(): string[] {
+        const commands = [
+            'interpreter-exec console "monitor halt"'
+        ];
+
+        return commands;
+    }
+
+    public swoAndRTTCommands(): string[] {
+        return [];
+    }
+
+    public restartCommands(): string[] {
+        const commands: string[] = [
+            'interpreter-exec console "monitor halt"',
+            'interpreter-exec console "monitor reset"'
+        ];
+
+        return commands;
+    }
+
+    public serverExecutable(): string {
+        return null;
+    }
+
+    public allocateRTTPorts(): Promise<void> {
+        return Promise.resolve();
+    }
+        
+    public serverArguments(): string[] {
+        return [];
+    }
+
+    public initMatch(): RegExp {
+        return null;
+    }
+
+    public serverLaunchStarted(): void {
+        if (this.args.swoConfig.enabled && this.args.swoConfig.source === 'probe' && os.platform() !== 'win32') {
+            const mkfifoReturn = ChildProcess.spawnSync('mkfifo', [this.swoPath]);
+            this.emit('event', new SWOConfigureEvent({
+                type: 'fifo',
+                args: this.args,
+                path: this.swoPath
+            }));
+        }
+    }
+
+    public serverLaunchCompleted(): void {
+        if (this.args.swoConfig.enabled) {
+            if (this.args.swoConfig.source === 'probe' && os.platform() === 'win32') {
+                this.emit('event', new SWOConfigureEvent({
+                    type: 'file',
+                    args: this.args,
+                    path: this.swoPath
+                }));
+            }
+            else if (this.args.swoConfig.source === 'socket') {
+                this.emit('event', new SWOConfigureEvent({
+                    type: 'socket',
+                    args: this.args,
+                    port: this.args.swoConfig.swoPort
+                }));
+            }
+            else if (this.args.swoConfig.source === 'file') {
+                this.emit('event', new SWOConfigureEvent({
+                    type: 'file',
+                    args: this.args,
+                    path: this.args.swoConfig.swoPath
+                }));
+            }
+            else if (this.args.swoConfig.source === 'serial') {
+                this.emit('event', new SWOConfigureEvent({
+                    type: 'serial',
+                    args: this.args,
+                    device: this.args.swoConfig.swoPath,
+                    baudRate: this.args.swoConfig.swoFrequency
+                }));
+            }
+        }
+    }
+
+    public debuggerLaunchStarted(): void {}
+    public debuggerLaunchCompleted(): void {}
+}


### PR DESCRIPTION
I am using a setup where I have a JLink GDB server running on an external system a lot.

The external server type worked for this, but it had errors on unexpected arguments for `monitor reset`

I coppied the external server type and replaced the launch/attach/restart commands to match the ones from the JLink server type.

Do you think this is the right approach or would you know a better one?