### PR TITLE
Add BMP connect_srst option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1617,6 +1617,10 @@
                             "powerOverBMP": {
                                 "type": "string",
                                 "description": "Power up the board over Black Magic Probe. \"powerOverBMP\" : \"enable\" or \"powerOverBMP\" : \"disable\". If not set it will use the last power state."
+                            },
+                            "bmpConnectUnderReset": {
+                                "type": "boolean",
+                                "description": "Configure connect under SRST."
                             }
                         },
                         "required": [
@@ -2728,6 +2732,10 @@
                             "powerOverBMP": {
                                 "type": "string",
                                 "description": "Power up the board over Black Magic Probe. \"powerOverBMP\" : \"enable\" or \"powerOverBMP\" : \"disable\". If not set it will use the last power state."
+                            },
+                            "bmpConnectUnderReset": {
+                                "type": "boolean",
+                                "description": "Configure connect under SRST."
                             }
                         },
                         "required": [
@@ -3050,6 +3058,7 @@
         "nan": "^2.14.2",
         "node-interval-tree": "^1.3.3",
         "prebuild-install": "^7.0.1",
+        "react": "^18.2.0",
         "ringbufferjs": "^1.1.0",
         "safe-buffer": "^5.2.1",
         "stream-json": "^1.7.3",

--- a/src/bmp.ts
+++ b/src/bmp.ts
@@ -31,6 +31,12 @@ export class BMPServerController extends EventEmitter implements GDBServerContro
             `target-select extended-remote ${this.args.BMPGDBSerialPort}`
         ];
 
+        if (this.args.bmpConnectUnderReset) {
+            commands.push('interpreter-exec console "monitor connect_rst enable"');
+        } else {
+            commands.push('interpreter-exec console "monitor connect_rst disable"');
+        }
+
         if (this.args.powerOverBMP === 'enable') {
             commands.push('interpreter-exec console "monitor tpwr enable"');
             // sleep for 100 ms. MCU need some time to boot up after power up

--- a/src/common.ts
+++ b/src/common.ts
@@ -325,6 +325,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     // BMP Specific
     BMPGDBSerialPort: string;
     powerOverBMP: string;
+    bmpConnectUnderReset: boolean;
 
     // QEMU Specific
     cpu: string;


### PR DESCRIPTION
Adds option `bmpConnectUnderReset` support to launch configuration.
When true,  `monitor connect_srst` is executed before swdp scan. Probe then issues reset to target before connecting.

https://black-magic.org/usage/gdb-commands.html
