### PR TITLE
Return memory references for `void *` variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ChangeLog
 =========
 
+# V1.6.6
+* `void *` variables now return `memoryReference` values.
+
 # V1.6.4
 * Issue #741: Could not determine gdb version from Fedora install
 

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -155,7 +155,8 @@ export class VariableObject {
     }
 
     private tryAddMemoryReference(result: object): void {
-        if ((this.numchild > 0) && this.value.startsWith('0x')) {
+        if ((this.numchild > 0 || this.type === "void *")
+            && this.value.startsWith('0x')) {
             result['memoryReference'] = hexFormat(parseInt(this.value));
         }
     }

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -155,7 +155,7 @@ export class VariableObject {
     }
 
     private tryAddMemoryReference(result: object): void {
-        if ((this.numchild > 0 || this.type === "void *")
+        if ((this.numchild > 0 || this.type === 'void *')
             && this.value.startsWith('0x')) {
             result['memoryReference'] = hexFormat(parseInt(this.value));
         }


### PR DESCRIPTION
This fixes https://github.com/microsoft/vscode-embedded-tools/issues/23. The issue was that Embedded Tools was attempting to get a `memoryReference` for `tx_thread_stack_start` to determine which region of memory to scan for a high water mark, but because `tx_thread_stack_start` is of type `void *`, it has no children and the `memoryReference` wasn't available.

I'm guessing this logic could be improved more (e.g. `int *` should probably also have a `memoryReference`) but as-is it fixes the issue the user was having with Embedded Tools.