### PR TITLE
Add preContinueCommands configuration option

### DIFF
--- a/debug_attributes.md
+++ b/debug_attributes.md
@@ -30,6 +30,7 @@ Also using IntelliSense while editing launch.json in VSCode can be quite helpful
 | preAttachCommands | Common | Additional GDB Commands to be executed at the start of the main attach sequence (immediately after attaching to target).
 | preLaunchCommands | Common | Additional GDB Commands to be executed at the start of the main launch sequence (immediately after attaching to target).
 | preRestartCommands | Common | Additional GDB Commands to be executed at the beginning of the restart sequence (after interrupting execution).
+| preContinueCommands | Common | Additional GDB Commands to be exectuted immediately before continuing.
 | request | Common | ????
 | rtos | Common | RTOS being used. For JLink this can be Azure, ChibiOS, embOS, FreeRTOS, NuttX, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be ChibiOS, eCos, embKernel, FreeRTOS, mqx, nuttx, ThreadX, uCOS-III, or auto.
 | rttConfig | Common | SEGGER's Real Time Trace (RTT) and supported by JLink, OpenOCD and perhaps others in the future

--- a/package.json
+++ b/package.json
@@ -610,6 +610,12 @@
                                 "items": "string",
                                 "description": "Additional GDB Commands to be executed at the end of the restart sequence."
                             },
+                            "preContinueCommands": {
+                                "default": [],
+                                "type": "array",
+                                "items": "string",
+                                "description": "Additional GDB Commands to be exectuted immediately before continuing."
+                            },
                             "overrideAttachCommands": {
                                 "default": null,
                                 "type": "array",

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -42,7 +42,7 @@ export interface IBackend {
     stop();
     detach();
     interrupt(arg: string): Thenable<boolean>;
-    continue(threadId: number): Thenable<boolean>;
+    continue(commands: string[], threadId: number): Thenable<boolean>;
     next(threadId: number, instruction: boolean): Thenable<boolean>;
     step(threadId: number, instruction: boolean): Thenable<boolean>;
     stepOut(threadId: number): Thenable<boolean>;

--- a/src/common.ts
+++ b/src/common.ts
@@ -260,6 +260,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     overrideLaunchCommands: string[];
     preAttachCommands: string[];
     postAttachCommands: string[];
+    preContinueCommands: string[];
     overrideAttachCommands: string[];
     preRestartCommands: string[];
     postRestartCommands: string[];

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -78,6 +78,7 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
         if (!config.postAttachCommands) { config.postAttachCommands = []; }
         if (!config.preRestartCommands) { config.preRestartCommands = []; }
         if (!config.postRestartCommands) { config.postRestartCommands = []; }
+        if (!config.preContinueCommands) { config.preContinueCommands = []; }
         if (config.runToEntryPoint) { config.runToEntryPoint = config.runToEntryPoint.trim(); }
         else if (config.runToMain) {
             config.runToEntryPoint = 'main';

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -3015,7 +3015,9 @@ export class GDBDebugSession extends LoggingDebugSession {
             if (this.args.ctiOpenOCDConfig?.enabled && this.args.ctiOpenOCDConfig?.resumeCommands && this.serverController.ctiStopResume) {
                 this.serverController.ctiStopResume(CTIAction.resume);
             } else {
-                const done = await this.miDebugger.continue(args.threadId);
+                const commands = [];
+                commands.push(...this.args.preContinueCommands.map(COMMAND_MAP));
+                const done = await this.miDebugger.continue(commands, args.threadId);
             }
             response.body = { allThreadsContinued: true };
             this.sendResponse(response);


### PR DESCRIPTION
I find it is very convenient to have some kind of global flag in my firmware which can disable certain features, such as watchdog and other system health monitors during debug (I know many processors halt the watchdog during break, however a software monitor based on tick count or time etc may not be paused).

I found no way to set the flag and then re-set it through device resets in the debugger. I could not use the `postRestartCommands` as these happen too early in the boot process (thus the flag is zeroed out by the crt initialization, which is what we do want!) and/or the target is not in break mode at the time when `postRestartCommands` are run.

Perhaps there is a way to execute a command eg `set debugger_attached=1` both on attach and also after the "Reset device" button is pressed, but I couldn't figure it out ;)

Using this new configuration as well as `runToEntryPoint`, after pressing "Reset device", the debugger will break at eg. main, and then when I press the continue button it will set the debugging flag as I want!
