### PR TITLE
Fix handling of optional parameters in stackTraceRequest

### DIFF
--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -2309,6 +2309,9 @@ export class GDBDebugSession extends LoggingDebugSession {
             stackFrames: [],
             totalFrames: 0
         };
+        // Handle optional args when not passed
+        args.startFrame = args.startFrame ?? 0;
+        args.levels = args.levels ?? Infinity;
         if (!this.isMIStatusStopped() || !this.stopped || this.disableSendStoppedEvents || this.continuing) {
             this.sendResponse(response);
             return Promise.resolve();


### PR DESCRIPTION
Hi, I was trying to use cortex-debug with [nvim-dap](https://github.com/mfussenegger/nvim-dap) and noticed an issue with stackTrace reqest. According to [DAP specification](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_StackTrace), `startFrame` and `levels` are optional and if ommitted it means "start from 0, all frames", but cortex-debug will use `undefined` in calculations and the resulting command contains literal `undefined` instead of numerical values. 