### PR TITLE
pre,post and override Reset commands

### DIFF
--- a/debug_attributes.md
+++ b/debug_attributes.md
@@ -22,14 +22,17 @@ Also using IntelliSense while editing launch.json in VSCode can be quite helpful
 | overrideGDBServerStartedRegex | Common | You can supply a regular expression (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) in the configuration property to override the output from the GDB Server that is looked for to determine if the GDB Server has started. Under most circumstances this will not be necessary - but could be needed as a result of a change in the output of a GDB Server making it incompatible with cortex-debug. This property has no effect for bmp or external GDB Server types.
 | overrideLaunchCommands | Common | You can use this to property to override the commands that are normally executed as part of flashing and launching the target. In most cases it is preferable to use preLaunchCommands and postLaunchCommands to customize the GDB launch sequence.
 | overrideRestartCommands | Common | You can use this to property to override the commands that are normally executed as part of restarting the target. In most cases it is preferable to use preRestartCommands and postRestartCommands to customize the GDB restart sequence.
+| overrideResetCommands | Common | You can use this to property to override the commands that are normally executed as part of reset the target. When not defined this will have the same value of overrideRestartCommands. In most cases it is preferable to use preResetCommands and postResetCommands to customize the GDB reset sequence.
 | postAttachCommands | Common | Additional GDB Commands to be executed after the main attach sequence has finished.
 | postLaunchCommands | Common | Additional GDB Commands to be executed after the main launch sequence has finished.
 | postRestartCommands | Common | Additional GDB Commands to be executed at the end of the restart sequence.
+| postResetCommands | Common | Additional GDB Commands to be executed at the end of the reset sequence. When not defined this will have the same value of postRestartCommands.
 | postRestartSessionCommands | Common | Additional GDB Commands to be executed at the end of the re-start sequence, after a debug session has already started.
 | postStartSessionCommands | Common | Additional GDB Commands to be executed at the end of the start sequence, after a debug session has already started and runToEntryPoint is not specified.
 | preAttachCommands | Common | Additional GDB Commands to be executed at the start of the main attach sequence (immediately after attaching to target).
 | preLaunchCommands | Common | Additional GDB Commands to be executed at the start of the main launch sequence (immediately after attaching to target).
 | preRestartCommands | Common | Additional GDB Commands to be executed at the beginning of the restart sequence (after interrupting execution).
+| preResetCommands | Common | Additional GDB Commands to be executed at the beginning of the reset sequence (after interrupting execution). When not defined this will have the same value of preRestartCommands.
 | request | Common | ????
 | rtos | Common | RTOS being used. For JLink this can be Azure, ChibiOS, embOS, FreeRTOS, NuttX, Zephyr or the path to a custom JLink RTOS Plugin library. For OpenOCD this can be ChibiOS, eCos, embKernel, FreeRTOS, mqx, nuttx, ThreadX, uCOS-III, or auto.
 | rttConfig | Common | SEGGER's Real Time Trace (RTT) and supported by JLink, OpenOCD and perhaps others in the future

--- a/package.json
+++ b/package.json
@@ -610,6 +610,18 @@
                                 "items": "string",
                                 "description": "Additional GDB Commands to be executed at the end of the restart sequence."
                             },
+                            "preResetCommands": {
+                                "default": [],
+                                "type": "array",
+                                "items": "string",
+                                "description": "Additional GDB Commands to be executed at the beginning of the reset sequence (after interrupting execution). When not defined this will have the same value of preRestartCommands."
+                            },
+                            "postResetCommands": {
+                                "default": [],
+                                "type": "array",
+                                "items": "string",
+                                "description": "Additional GDB Commands to be executed at the end of the reset sequence. When not defined this will have the same value of postRestartCommands."
+                            },
                             "overrideAttachCommands": {
                                 "default": null,
                                 "type": "array",
@@ -621,6 +633,12 @@
                                 "type": "array",
                                 "items": "string",
                                 "description": "You can use this to property to override the commands that are normally executed as part of restarting the target. In most cases it is preferable to use preRestartCommands and postRestartCommands to customize the GDB restart sequence."
+                            },
+                            "overrideResetCommands": {
+                                "default": null,
+                                "type": "array",
+                                "items": "string",
+                                "description": "You can use this to property to override the commands that are normally executed as part of reset the target. When not defined this will have the same value of overrideRestartCommands. In most cases it is preferable to use preResetCommands and postResetCommands to customize the GDB reset sequence."
                             },
                             "postStartSessionCommands": {
                                 "default": [],
@@ -1673,6 +1691,18 @@
                                 "items": "string",
                                 "description": "Additional GDB Commands to be executed at the end of the restart sequence."
                             },
+                            "preResetCommands": {
+                                "default": [],
+                                "type": "array",
+                                "items": "string",
+                                "description": "Additional GDB Commands to be executed at the beginning of the reset sequence (after interrupting execution). When not defined this will have the same value of preRestartCommands."
+                            },
+                            "postResetCommands": {
+                                "default": [],
+                                "type": "array",
+                                "items": "string",
+                                "description": "Additional GDB Commands to be executed at the end of the reset sequence. When not defined this will have the same value of postRestartCommands."
+                            },
                             "overrideLaunchCommands": {
                                 "default": null,
                                 "type": "array",
@@ -1684,6 +1714,12 @@
                                 "type": "array",
                                 "items": "string",
                                 "description": "You can use this to property to override the commands that are normally executed as part of restarting the target. In most cases it is preferable to use preRestartCommands and postRestartCommands to customize the GDB restart sequence."
+                            },
+                            "overrideResetCommands": {
+                                "default": null,
+                                "type": "array",
+                                "items": "string",
+                                "description": "You can use this to property to override the commands that are normally executed as part of reset the target. When not defined this will have the same value of overrideRestartCommands. In most cases it is preferable to use preResetCommands and postResetCommands to customize the GDB reset sequence."
                             },
                             "postStartSessionCommands": {
                                 "default": [],

--- a/src/common.ts
+++ b/src/common.ts
@@ -264,6 +264,9 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     preRestartCommands: string[];
     postRestartCommands: string[];
     overrideRestartCommands: string[];
+    preResetCommands: string[];
+    postResetCommands: string[];
+    overrideResetCommands: string[];
     postStartSessionCommands: string[];
     postRestartSessionCommands: string[];
     overrideGDBServerStartedRegex: string;

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -78,6 +78,8 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
         if (!config.postAttachCommands) { config.postAttachCommands = []; }
         if (!config.preRestartCommands) { config.preRestartCommands = []; }
         if (!config.postRestartCommands) { config.postRestartCommands = []; }
+        if (!config.preResetCommands) { config.preResetCommands = config.preRestartCommands; }
+        if (!config.postResetCommands) { config.postResetCommands = config.postRestartCommands; }
         if (config.runToEntryPoint) { config.runToEntryPoint = config.runToEntryPoint.trim(); }
         else if (config.runToMain) {
             config.runToEntryPoint = 'main';


### PR DESCRIPTION
* Reset and Restart command will now behave differently
* preRestartCommands, postRestartCommands, overrideRestartCommands will work only for restart.
* preResetCommands, postResetCommands, overrideResetCommands will work only for reset.
* By default Reset and Restart default comands are identical.

This allows the user to not have to stop/restart the debug session if a new build is needed.
Example before PR
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Cortex Debug - PyOCD",
            "cwd": "${workspaceFolder}",
            "executable": "${command:cmake.launchTargetPath}",
            "request": "launch",
            "type": "cortex-debug",
            "runToEntryPoint": "main",
            "servertype": "pyocd",
            "targetId" : "stm32f217ietx",
            "serverArgs": [
                "--pack=C:/Users/Cisco.Cervellera/Downloads/Keil.STM32F2xx_DFP.2.9.0.pack",
                "--semihosting",
                "-Osemihost_console_type=console",
            ],
            "svdFile": "C:/Users/cisco.cervellera/Downloads/STM32F21x.svd",
            "showDevDebugOutput": "raw",
            "preLaunchTask" : "${defaultBuildTask}",
            "preRestartCommands": [
                "load"],
        },
    ]
}
```
This would call load everytime also on reset (which is not needed and time consuming).
With the proposed PR the `load` comand will be called only on Restart which will also call the `defaultBuildTask`.

The Wiki will needed to be updated to reflect this changes.

Happy to answare question.