### PR TITLE
Add peripheral tree refresh and collapse commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -447,6 +447,16 @@
                 "icon": "$(refresh)"
             },
             {
+                "command": "cortex-debug.peripherals.refreshAll",
+                "title": "Refresh All",
+                "icon": "$(refresh)"
+            },
+            {
+                "command": "cortex-debug.peripherals.collapseAll",
+                "title": "Collapse All",
+                "icon": "$(collapse-all)"
+            },
+            {
                 "command": "cortex-debug.peripherals.pin",
                 "title": "Pin",
                 "icon": "$(pin)"
@@ -2869,6 +2879,14 @@
                     "when": "false"
                 },
                 {
+                    "command": "cortex-debug.peripherals.refreshAll",
+                    "when": "false"
+                },
+                {
+                    "command": "cortex-debug.peripherals.collapseAll",
+                    "when": "false"
+                },
+                {
                     "command": "cortex-debug.peripherals.pin",
                     "when": "false"
                 },
@@ -3006,8 +3024,13 @@
                     "group": "navigation"
                 },
                 {
-                    "command": "cortex-debug.peripherals.forceRefresh",
+                    "command": "cortex-debug.peripherals.refreshAll",
                     "when": "view == cortex-debug.peripherals && debugState == stopped",
+                    "group": "navigation"
+                },
+                {
+                    "command": "cortex-debug.peripherals.collapseAll",
+                    "when": "view == cortex-debug.peripherals",
                     "group": "navigation"
                 }
             ],

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -93,6 +93,9 @@ export class CortexDebugExtension {
             vscode.commands.registerCommand('cortex-debug.peripherals.copyValue', this.peripheralsCopyValue.bind(this)),
             vscode.commands.registerCommand('cortex-debug.peripherals.setFormat', this.peripheralsSetFormat.bind(this)),
             vscode.commands.registerCommand('cortex-debug.peripherals.forceRefresh', this.peripheralsForceRefresh.bind(this)),
+            vscode.commands.registerCommand('cortex-debug.peripherals.refreshAll', () => this.peripheralsForceRefresh()),
+            vscode.commands.registerCommand('cortex-debug.peripherals.collapseAll', () => this.peripheralsCollapseAll()),
+
             vscode.commands.registerCommand('cortex-debug.peripherals.pin', this.peripheralsTogglePin.bind(this)),
             vscode.commands.registerCommand('cortex-debug.peripherals.unpin', this.peripheralsTogglePin.bind(this)),
             
@@ -547,14 +550,18 @@ export class CortexDebugExtension {
         Reporting.sendEvent('Peripheral View', 'Set Format', result.label);
     }
 
-    private async peripheralsForceRefresh(node: PeripheralBaseNode): Promise<void> {
+    private async peripheralsForceRefresh(node?: PeripheralBaseNode): Promise<void> {
         if (node) {
             node.getPeripheral().updateData().then((e) => {
                 this.peripheralProvider.refresh();
             });
         } else {
-            this.peripheralProvider.refresh();
+            this.peripheralProvider.updateData();
         }
+    }
+
+    private peripheralsCollapseAll(): void {
+        this.peripheralProvider.collapseAll();
     }
 
     private async peripheralsTogglePin(node: PeripheralBaseNode): Promise<void> {

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -972,7 +972,7 @@ export class CortexDebugExtension {
     private receivedContinuedEvent(e: vscode.DebugSessionCustomEvent) {
         const mySession = CDebugSession.FindSession(e.session);
         mySession.status = 'running';
-        this.peripheralProvider.debugContinued();
+        this.peripheralProvider.debugContinued(e.session);
         if (this.isDebugging(e.session)) {
             this.registerProvider.debugContinued();
         }

--- a/src/frontend/views/peripheral.ts
+++ b/src/frontend/views/peripheral.ts
@@ -19,6 +19,7 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
     private gapThreshold: number = 16;
     private errMessage: string = 'No SVD file loaded';
     private wsFolderPath: string;
+    private stopped = false;
     
     constructor(
         public session: vscode.DebugSession,
@@ -75,7 +76,7 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
         throw new Error('Method not implemented.');
     }
     public updateData(): Thenable<boolean> {
-        if (this.loaded) {
+        if (this.loaded && this.stopped) {
             const promises = this.peripherials.map((p) => p.updateData());
             Promise.all(promises).then((_) => { this.fireCb(); }, (_) => { this.fireCb(); });
         }
@@ -183,6 +184,14 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
         node.pinned = !node.pinned;
         this.peripherials.sort(PeripheralNode.compare);
     }
+
+    public sessionStopped() {
+        this.stopped = true;
+    }
+
+    public sessionContinued() {
+        this.stopped = false;
+    }
 }
 export class PeripheralTreeProvider implements vscode.TreeDataProvider<PeripheralBaseNode> {
     // tslint:disable-next-line:variable-name
@@ -274,11 +283,16 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
     public debugStopped(session: vscode.DebugSession) {
         const regs = this.sessionPeripheralsMap.get(session.id);
         if (regs) {     // We are called even before the session has started, as part of reset
+            regs.sessionStopped();
             regs.updateData();
         }
     }
 
-    public debugContinued() {
+    public debugContinued(session: vscode.DebugSession) {
+        const regs = this.sessionPeripheralsMap.get(session.id);
+        if (regs) {
+            regs.sessionContinued();
+        }
     }
 
     public togglePinPeripheral(node: PeripheralBaseNode) {

--- a/src/frontend/views/peripheral.ts
+++ b/src/frontend/views/peripheral.ts
@@ -234,7 +234,7 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
     }
 
     public collapseAll(): void {
-        vscode.commands.executeCommand(`workbench.actions.treeView.cortex-debug.peripherals.collapseAll`);
+        vscode.commands.executeCommand('workbench.actions.treeView.cortex-debug.peripherals.collapseAll');
     }
 
     public debugSessionStarted(session: vscode.DebugSession, svdfile: string, thresh: any): Thenable<any> {

--- a/src/frontend/views/peripheral.ts
+++ b/src/frontend/views/peripheral.ts
@@ -215,6 +215,19 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
         }
     }
 
+    public async updateData(): Promise<void> {
+        const trees = this.sessionPeripheralsMap.values();
+        for (const tree of trees) {
+            await tree.updateData();
+        }
+
+        this.refresh();
+    }
+
+    public collapseAll(): void {
+        vscode.commands.executeCommand(`workbench.actions.treeView.cortex-debug.peripherals.collapseAll`);
+    }
+
     public debugSessionStarted(session: vscode.DebugSession, svdfile: string, thresh: any): Thenable<any> {
         return new Promise<void>(async (resolve, reject) => {
             if (!svdfile) {


### PR DESCRIPTION
As outlined in #803, the tree refresh command only refreshes the highlighted node. This is due to the command passing the selected node to the `peripheralsForceRefresh()` function.

This PR adds a new command for refresh which ignores the selected node. The functionality was also missing to recurse the trees and refresh the expanded nodes, so this has also been added.

As suggested, I've also exposed a `Collapse All` command.

Fixes #803 