### PR TITLE
add new stmcube path for windows

### DIFF
--- a/src/stlink.ts
+++ b/src/stlink.ts
@@ -8,7 +8,9 @@ import { EventEmitter } from 'events';
 function get_ST_DIR() {
     switch (os.platform()) {
         case 'win32':
-            return 'C:\\ST';
+            const oldDirName = 'C:\\ST';
+            const newDirName = 'C:\\Program Files\\STMicroelectronics';
+            return fs.existsSync(newDirName) ? newDirName : oldDirName;
         case 'darwin':
             return '/Applications/STM32CubeIDE.app/Contents/Eclipse';
         default:


### PR DESCRIPTION
ST seems to have changed the default installation path for STMCubeIDE. Has anyone else experienced this?