### PR TITLE
Allow printing defmt output to the RTT console

### DIFF
--- a/package.json
+++ b/package.json
@@ -1134,10 +1134,11 @@
                                                         "type": {
                                                             "enum": [
                                                                 "console",
-                                                                "binary"
+                                                                "binary",
+                                                                "defmt"
                                                             ],
                                                             "default": "console",
-                                                            "description": "'console' with text input/output, 'binary' is for converting byte stream to other data types",
+                                                            "description": "'console' with text input/output, 'binary' is for converting byte stream to other data types, 'defmt' uses defmt-print",
                                                             "type": "string"
                                                         },
                                                         "prompt": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -456,13 +456,14 @@ export class RTTServerHelper {
         });
     }
 
-    public emitConfigures(cfg: RTTConfiguration, obj: EventEmitter): boolean {
+    public emitConfigures(cfg: RTTConfiguration, executable: string, obj: EventEmitter): boolean {
         let ret = false;
         if (cfg.enabled) {
             for (const dec of cfg.decoders) {
                 if (dec.tcpPort || dec.tcpPorts) {
                     obj.emit('event', new RTTConfigureEvent({
                         type: 'socket',
+                        executable: executable,
                         decoder: dec
                     }));
                     ret = true;

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -12,7 +12,7 @@ import { MemoryContentProvider } from './memory_content_provider';
 import Reporting from '../reporting';
 
 import { CortexDebugConfigurationProvider } from './configprovider';
-import { JLinkSocketRTTSource, SocketRTTSource, SocketSWOSource, PeMicroSocketSource } from './swo/sources/socket';
+import { JLinkSocketRTTSource, SocketRTTSource, SocketSWOSource, PeMicroSocketSource, DefmtSocketRTTSource } from './swo/sources/socket';
 import { FifoSWOSource } from './swo/sources/fifo';
 import { FileSWOSource } from './swo/sources/file';
 import { SerialSWOSource } from './swo/sources/serial';
@@ -770,7 +770,7 @@ export class CortexDebugExtension {
     private receivedRTTConfigureEvent(e: vscode.DebugSessionCustomEvent) {
         if (e.body.type === 'socket') {
             const decoder: RTTCommonDecoderOpts = e.body.decoder;
-            if ((decoder.type === 'console') || (decoder.type === 'binary')) {
+            if ((decoder.type === 'console') || (decoder.type === 'binary') || (decoder.type === 'defmt')) {
                 Reporting.sendEvent('RTT', 'Source', 'Socket: Console');
                 this.rttCreateTerninal(e, decoder as RTTConsoleDecoderOpts);
             } else {
@@ -793,6 +793,7 @@ export class CortexDebugExtension {
     // state.
     private createRTTSource(e: vscode.DebugSessionCustomEvent, tcpPort: string, channel: number): Promise<SocketRTTSource> {
         const mySession = CDebugSession.GetSession(e.session);
+        const wsPath = e.session.workspaceFolder.uri.fsPath;
         return new Promise((resolve, reject) => {
             let src = mySession.rttPortMap[channel];
             if (src) {
@@ -801,6 +802,8 @@ export class CortexDebugExtension {
             }
             if (mySession.config.servertype === 'jlink') {
                 src = new JLinkSocketRTTSource(tcpPort, channel);
+            } else if (e.body.decoder.type === 'defmt') {
+                src = new DefmtSocketRTTSource(tcpPort, channel, e.body.executable, wsPath);
             } else {
                 src = new SocketRTTSource(tcpPort, channel);
             }

--- a/src/jlink.ts
+++ b/src/jlink.ts
@@ -222,6 +222,6 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
     }
     public debuggerLaunchStarted(): void {}
     public debuggerLaunchCompleted(): void {
-        this.rttHelper.emitConfigures(this.args.rttConfig, this);
+        this.rttHelper.emitConfigures(this.args.rttConfig, this.args.executable, this);
     }
 }

--- a/src/openocd.ts
+++ b/src/openocd.ts
@@ -307,7 +307,7 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
         this.session = obj;
     }
     public debuggerLaunchCompleted(): void {
-        const hasRtt = this.rttHelper.emitConfigures(this.args.rttConfig, this);
+        const hasRtt = this.rttHelper.emitConfigures(this.args.rttConfig, this.args.executable, this);
         if (this.args.ctiOpenOCDConfig?.enabled) {
             this.ctiStopResume(CTIAction.init);
         }


### PR DESCRIPTION
defmt is widely used as a logger in the rust embedded ecosystem. This allows seamlessly debugging a rust program while printing defmt output at the same time.

