### PR TITLE
Adding languages(c,cpp) for which the debugger option will be prompted.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2855,7 +2855,11 @@
                 "program": "./dist/debugadapter.js",
                 "runtime": "node",
                 "type": "cortex-debug",
-                "variables": {}
+                "variables": {},
+                "languages": [
+                    "c",
+                    "cpp"
+                ]
             }
         ],
         "menus": {


### PR DESCRIPTION
Resolving issue [#897] by updating the relevant code in pacakge.json. This code adds the `cortex-debug` configuration suggestion for `.c` and `.cpp` files, if there is a need to support more file formats we can add them in the array.