### PR TITLE
Updating method to add initial debug configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2840,17 +2840,6 @@
                         "label": "Cortex Debug: ST-Util"
                     }
                 ],
-                "initialConfigurations": [
-                    {
-                        "name": "Cortex Debug",
-                        "cwd": "${workspaceFolder}",
-                        "executable": "./bin/executable.elf",
-                        "request": "launch",
-                        "type": "cortex-debug",
-                        "runToEntryPoint": "main",
-                        "servertype": "jlink"
-                    }
-                ],
                 "label": "Cortex Debug",
                 "program": "./dist/debugadapter.js",
                 "runtime": "node",

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -29,6 +29,18 @@ const JLINK_VALID_RTOS: string[] = ['Azure', 'ChibiOS', 'embOS', 'FreeRTOS', 'Nu
 export class CortexDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
     constructor(private context: vscode.ExtensionContext) {}
 
+    public provideDebugConfigurations(): vscode.ProviderResult<vscode.DebugConfiguration[]> {
+        return [{
+            name: 'Cortex Debug',
+            cwd: '${workspaceFolder}',
+            executable: './bin/executable.elf',
+            request: 'launch',
+            type: 'cortex-debug',
+            runToEntryPoint: 'main',
+            servertype: 'jlink'
+        }];
+    }
+    
     public resolveDebugConfiguration(
         folder: vscode.WorkspaceFolder | undefined,
         config: vscode.DebugConfiguration,


### PR DESCRIPTION
Updating debug configuration provider, instead of using initialConfigurations in package.json, which is deprecated, using function provideDebugConfigurations. 

The issue targeted is [this](https://github.com/Marus/cortex-debug/issues/901).
