### PR TITLE
Emit GrapherDataMessage correctly for AdvancedDecoder

### DIFF
--- a/src/frontend/swo/decoders/advanced.ts
+++ b/src/frontend/swo/decoders/advanced.ts
@@ -65,7 +65,7 @@ export class SWORTTAdvancedProcessor extends EventEmitter implements SWORTTDecod
 
     public graphData(data: number, id: string) {
         const message: GrapherDataMessage = { type: 'data', data: data, id: id };
-        this.emit('data', message);
+        this.emit('message', message);
     }
 
     public dispose() {


### PR DESCRIPTION
Hi there,

I was working on a custom [TraceDecoder](https://github.com/aq1018/cortex-debug-trace-decoder) to display trace data via RTT. However, I wasn't seeing any data being displayed on the real time graph. After looking at the difference between the `GraphDecoder` and `AdvancedDecoder`, I realized that the `AdvancedDecoder.graphData()` was emitting `data` event, where as the `GraphDecoder` was emitting `message` event. After making the tweak, I was able to get the trace data showing nicely on the graph.

<img width="496" alt="Screenshot 2023-11-26 at 6 17 40 AM" src="https://github.com/Marus/cortex-debug/assets/18140/2d011dd9-b481-4aa0-904a-18d0327842a2">

<img width="572" alt="Screenshot 2023-11-26 at 6 18 14 AM" src="https://github.com/Marus/cortex-debug/assets/18140/e8ac83dc-3906-426b-af9d-b5a7d38027df">

