### PR TITLE
Feature/Line information for customRequest disassemble

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -348,6 +348,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
 }
 
 export interface DisassemblyInstruction {
+    line: number;
     address: string;
     functionName: string;
     offset: number;


### PR DESCRIPTION
This PR adds support for line information about a instruction when running the customRequest `disassemble`. This is so custom plugins can see what line in the source file the instruction belongs to.

This changes `data-disassemble` from mode 2 (disassembly with raw opcodes) to mode 5 (mixed source and disassembly with raw opcodes). This gives line information combined with the raw opcodes (in a slightly different format).


I am currently working on a plugin that adds support for streaming traces (such as the j-trace) and showing the live instruction counters during runtime (still WIP). This would speed up the start time as it would mean I no longer have to call `addr2line` for every instruction.

![trace_information](https://github.com/Marus/cortex-debug/assets/9889898/989acc25-9b8e-4e89-9f79-08d2e9fed563)
