### PR TITLE
Force tcl connection to IPv4

### DIFF
--- a/src/openocd.ts
+++ b/src/openocd.ts
@@ -421,7 +421,7 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
                 const tclPortName = createPortName(0, 'tclPort');
                 const tclPortNum = this.ports[tclPortName];
                 const obj = {
-                    host: 'localhost',
+                    host: '127.0.0.1',
                     port: tclPortNum
                 };
                 this.tclSocket = net.createConnection(obj, () => {


### PR DESCRIPTION
I first looked for https://github.com/Marus/cortex-debug/issues/959 to find a solution but in the end I compiled this project from source to find the root cause.
After updating on the latest Debian testing, the Rtt connection no longer worked. I wondered why. As it seems, OpenOCD doesn't listen on IPv6 sockets for tcl connection.
Changing to IPv4 allowed to me to continue. This might not be the ideal solution.
I'm creating this PR to at least provide information about this problem.

I don't know why this even started but localhost is resolved to ::1 on my system and not 127.0.0.1 as it was for a long time now. Maybe other applications are suffering with this change I imagine and it will be rolled back...

telnet solved this by first trying ::1 and then retrying with 127.0.0.1 if a connection to localhost shall be established.
