### PR TITLE
Fix the openocd tcl socket connection problem

### DIFF
--- a/src/openocd.ts
+++ b/src/openocd.ts
@@ -421,7 +421,7 @@ export class OpenOCDServerController extends EventEmitter implements GDBServerCo
                 const tclPortName = createPortName(0, 'tclPort');
                 const tclPortNum = this.ports[tclPortName];
                 const obj = {
-                    host: 'localhost',
+                    host: '127.0.0.1',
                     port: tclPortNum
                 };
                 this.tclSocket = net.createConnection(obj, () => {


### PR DESCRIPTION
The openocd tcl socket connection problem is caused by the host name 'localhost' which is resolved to '::1' on some systems. This patch changes the host name to '127.0.0.1' to avoid the problem.

This patch is related these issues:
https://github.com/Marus/cortex-debug/issues/999
