### PR TITLE
SWO support when using ST-LINK GDB server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     * It is not clear what (should) happens when you use the `Restart` button when multiple debuggers are active at the same time. For instance in a multi-core session. It may work, but we have not tested it.
   * This is the reason why we implemented the `Reset` button a while ago because VSCode `Restart` meant different (undocumented) behaviors at different times.
   * As a result, all the Restart related launch.json properties no longer apply. But, for compatibility reasons, they still exist and used by the `Reset` functionality when a `Reset` specific property does not exist. This is what used to happen in the previous releases.
+* ST-LINK GDB server (*not* st-util) now supports SWO functionality, using standard configuration options.
 
 # V1.12.1
 * Fix for [#923: Local variables with same name between functions not tracking or updating context](https://github.com/Marus/cortex-debug/issues/923)
@@ -27,9 +28,9 @@ This is a major release. It has been in pre-release for quite a while and some o
   * [RTOS Views](https://marketplace.visualstudio.com/items?itemName=mcu-debug.rtos-views)
   * [Memory View](https://marketplace.visualstudio.com/items?itemName=mcu-debug.memory-view)
   * [Peripheral Viewer](https://marketplace.visualstudio.com/items?itemName=mcu-debug.peripheral-viewer)
- 
+
  *Note: Please install this extension using VSCode with a working internet connection. Do not try to install it manually. If you install it manually, then also make sure all the other dependent extensions are installed.*
-  
+
 # V1.11.3
 * Issue #861: Potential fix
 * Issue #867: STLink make it so that user has to enable `-shared` if needed. Before it was automatically added to the command-line and there was no (good) way to remove it

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Debugging support for ARM Cortex-M Microcontrollers with the following features:
 
 * Highly configurable. See https://github.com/Marus/cortex-debug/blob/master/debug_attributes.md
-* Support J-Link, OpenOCD GDB Server, STMicroelectronic's ST-LINK GDB server (no SWO support yet), pyOCD
+* Support J-Link, OpenOCD GDB Server, STMicroelectronic's ST-LINK GDB server, pyOCD
 * Initial support for the Black Magic Probe (This has not been as heavily tested; SWO can only be captured via a serial port)
 * Partial support textane/stlink (st-util) GDB Servers (SWO can only be captured via a serial port)
 * Multi-core and multi-session debugging. See https://github.com/Marus/cortex-debug/wiki/Multi-core-debugging

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -589,12 +589,6 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
             return 'The ST-Link GDB Server does not have support for the rtos option.';
         }
 
-        if (config.swoConfig.enabled && config.swoConfig.source === 'probe') {
-            vscode.window.showWarningMessage('SWO support is not available from the probe when using the ST-Link GDB server. Disabling SWO.');
-            config.swoConfig = { enabled: false, ports: [], cpuFrequency: 0, swoFrequency: 0 };
-            config.graphConfig = [];
-        }
-
         return null;
     }
 

--- a/src/frontend/swo/core.ts
+++ b/src/frontend/swo/core.ts
@@ -289,9 +289,14 @@ export class SWOCore extends SWORTTCoreBase {
         }, (error) => {
             this.functionSymbols = [];
         });
-        
-        if (this.source.connected) { this.connected = true; }
-        else { this.source.on('connected', () => { this.connected = true; }); }
+
+        const onConnected = () => {
+            this.connected = true;
+            session.customRequest('swo-connected');
+        };
+
+        if (this.source.connected) { onConnected(); }
+        else { this.source.on('connected', onConnected); }
         this.source.on('data', this.handleData.bind(this));
         this.source.on('disconnected', this.handleDisconnected.bind(this));
 


### PR DESCRIPTION
Adds the ability to use the raw SWO stream from the ST-LINK debugger.

One important change is waiting for SWO connection during startup - this seems to be necessary because starting the actual launch completely confuses ST-LINK's GDB and leaves it in a semi-frozen state. I'm sure this change should be beneficial for other adapters as well as I've seen SWO randomly not working from time to time and this is a possible explanation.

For the future, we could consider refactoring the GDB server controllers for better code sharing, there is not much about SWO init that is server specific, other than an occasional `monitor` command.