### PR TITLE
fix: incorrect RingBuffer import after no-require-imports

### DIFF
--- a/src/frontend/swo/core.ts
+++ b/src/frontend/swo/core.ts
@@ -19,7 +19,7 @@ import { SymbolInformation } from '../../symbols';
 import { getNonce, RTTCommonDecoderOpts } from '../../common';
 import { SocketRTTSource, SocketSWOSource } from './sources/socket';
 
-import RingBuffer from 'ringbufferjs';
+import * as RingBuffer from 'ringbufferjs';
 
 enum Status {
     IDLE = 1,


### PR DESCRIPTION
@haneefdm sorry, I have accidentally injected an issue into SWO startup when fixing some of the simpler rule violations.