### PR TITLE
Fix path normalization on windows.

### DIFF
--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -476,6 +476,9 @@ export class GDBDebugSession extends LoggingDebugSession {
 
         if (args.executable && !path.isAbsolute(args.executable)) {
             args.executable = path.normalize(path.join(args.cwd, args.executable));
+            if(os.platform().startsWith("win")){
+                args.executable = args.executable.replace(/\\/ig,"/");
+            }
         }
 
         if (args.svdFile && !path.isAbsolute(args.svdFile)) {

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -476,8 +476,8 @@ export class GDBDebugSession extends LoggingDebugSession {
 
         if (args.executable && !path.isAbsolute(args.executable)) {
             args.executable = path.normalize(path.join(args.cwd, args.executable));
-            if(os.platform().startsWith("win")){
-                args.executable = args.executable.replace(/\\/ig,"/");
+            if (os.platform() === 'win32') {
+                args.executable = args.executable.replace(/\\/ig, '/');
             }
         }
 


### PR DESCRIPTION
The `path.normalize()` function returns a path with the `\\` on windows. so i did a check after the normalize to replace the `\\` if the platform is windows.