### PR TITLE
always report gdb launch errors during launch (fixes #1096)

### DIFF
--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -575,7 +575,9 @@ export class GDBDebugSession extends LoggingDebugSession {
                 return doResolve();
             }
             const symbolsPromise = this.loadSymbols();      // This is totally async and in most cases, done while gdb is starting
+            let gdbPromiseAsyncErr;
             const gdbPromise = this.startGdb(response);
+            gdbPromise.catch((err) => { gdbPromiseAsyncErr = err });
             this.usingParentServer = this.args.pvtMyConfigFromParent && !this.args.pvtMyConfigFromParent.detached;
             this.getTCPPorts(this.usingParentServer).then(async () => {
                 await this.serverController.allocateRTTPorts();     // Must be done before serverArguments()
@@ -648,6 +650,8 @@ export class GDBDebugSession extends LoggingDebugSession {
                         // 3. Found free TCP ports and launched gdb-server
                         // 4. Finished reading symbols from objdump and nm
                         const showTimes = this.args.showDevDebugOutput && this.args.showDevDebugTimestamps;
+                        if (gdbPromiseAsyncErr)
+                            throw gdbPromiseAsyncErr;
                         await gdbPromise;
                         if (showTimes) { this.handleMsg('log', 'Debug Time: GDB Ready...\n'); }
 

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -577,7 +577,9 @@ export class GDBDebugSession extends LoggingDebugSession {
             const symbolsPromise = this.loadSymbols();      // This is totally async and in most cases, done while gdb is starting
             let gdbPromiseAsyncErr;
             const gdbPromise = this.startGdb(response);
-            gdbPromise.catch((err) => { gdbPromiseAsyncErr = err });
+            gdbPromise.catch((err) => {
+                gdbPromiseAsyncErr = err;
+            });
             this.usingParentServer = this.args.pvtMyConfigFromParent && !this.args.pvtMyConfigFromParent.detached;
             this.getTCPPorts(this.usingParentServer).then(async () => {
                 await this.serverController.allocateRTTPorts();     // Must be done before serverArguments()


### PR DESCRIPTION
I'm not well-enough versed in JavaScript async & Promises and the way they interact to be sure about this, but as far as I can tell, the problem seems to be that if the Node interpreter runs out of events to process and still has some rejected promises with no reject handlers registered, it considers that an error and crashes with a stack trace. This patch makes sure that control is never handed back to the event loop with no reject handler registered for `gdbPromise`.

I'm not 100% confident in my diagnosis or solution, but it works for me, both with and without the breakpoint I described in #1096. If someone with more understanding of the interaction between async/await and Promises wants to steer me in a different direction, I'm interested.