### PR TITLE
Enable/Disable Hex mode button: modify setting in existing location

### DIFF
--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -331,6 +331,30 @@ export class CortexDebugExtension {
         );
     }
 
+    private getConfigSource(config: vscode.WorkspaceConfiguration, section: string): [vscode.ConfigurationTarget, boolean] {
+        const configurationTargetMapping: [string, vscode.ConfigurationTarget][] = [
+            ['workspaceFolderValue', vscode.ConfigurationTarget.WorkspaceFolder],
+            ['workspaceValue', vscode.ConfigurationTarget.Workspace],
+            ['globalValue', vscode.ConfigurationTarget.Global],
+            // Modify user settings if setting isn't configured yet
+            ['defaultValue', vscode.ConfigurationTarget.Global],
+        ];
+        const info = config.inspect(section);
+        for (const mapping of configurationTargetMapping) {
+            const [inspectKey, mappingTarget] = mapping;
+            const inspectLanguageKey = inspectKey.replace('Value', 'LanguageValue');
+            if (info[inspectLanguageKey] !== undefined)
+                return [mappingTarget, true];
+            if (info[inspectKey] !== undefined)
+                return [mappingTarget, false];
+        }
+        // Shouldn't get here unless new configuration targets get added to the
+        // VSCode API, only those sources have values for this setting, and this
+        // setting doesn't have a default value. Still, do something rational
+        // just in case.
+        return [vscode.ConfigurationTarget.Global, false];
+    }
+
     // Settings changes
     private variablesNaturalMode(newVal: boolean, cxt?: any) {
         // 'cxt' contains the treeItem on which this menu was invoked. Maybe we can do something
@@ -339,7 +363,8 @@ export class CortexDebugExtension {
 
         vscode.commands.executeCommand('setContext', `cortex-debug:${CortexDebugKeys.VARIABLE_DISPLAY_MODE}`, newVal);
         try {
-            config.update(CortexDebugKeys.VARIABLE_DISPLAY_MODE, newVal);
+            const [target, languageOverride] = this.getConfigSource(config, CortexDebugKeys.VARIABLE_DISPLAY_MODE);
+            config.update(CortexDebugKeys.VARIABLE_DISPLAY_MODE, newVal, target, languageOverride);
         } catch (e) {
             console.error(e);
         }
@@ -353,7 +378,8 @@ export class CortexDebugExtension {
         const newVal = !curVal;
         vscode.commands.executeCommand('setContext', `cortex-debug:${CortexDebugKeys.VARIABLE_DISPLAY_MODE}`, newVal);
         try {
-            config.update(CortexDebugKeys.VARIABLE_DISPLAY_MODE, newVal);
+            const [target, languageOverride] = this.getConfigSource(config, CortexDebugKeys.VARIABLE_DISPLAY_MODE);
+            config.update(CortexDebugKeys.VARIABLE_DISPLAY_MODE, newVal, target, languageOverride);
         } catch (e) {
             console.error(e);
         }

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -333,20 +333,20 @@ export class CortexDebugExtension {
 
     private getConfigSource(config: vscode.WorkspaceConfiguration, section: string): [vscode.ConfigurationTarget, boolean] {
         const configurationTargetMapping: [string, vscode.ConfigurationTarget][] = [
-            ['workspaceFolderValue', vscode.ConfigurationTarget.WorkspaceFolder],
-            ['workspaceValue', vscode.ConfigurationTarget.Workspace],
-            ['globalValue', vscode.ConfigurationTarget.Global],
+            ['workspaceFolder', vscode.ConfigurationTarget.WorkspaceFolder],
+            ['workspace', vscode.ConfigurationTarget.Workspace],
+            ['global', vscode.ConfigurationTarget.Global],
             // Modify user settings if setting isn't configured yet
-            ['defaultValue', vscode.ConfigurationTarget.Global],
+            ['default', vscode.ConfigurationTarget.Global],
         ];
         const info = config.inspect(section);
-        for (const mapping of configurationTargetMapping) {
-            const [inspectKey, mappingTarget] = mapping;
-            const inspectLanguageKey = inspectKey.replace('Value', 'LanguageValue');
-            if (info[inspectLanguageKey] !== undefined)
-                return [mappingTarget, true];
-            if (info[inspectKey] !== undefined)
-                return [mappingTarget, false];
+        for (const inspectKeySuffix of ['LanguageValue', 'Value']) {
+            for (const mapping of configurationTargetMapping) {
+                const [inspectKeyPrefix, mappingTarget] = mapping;
+                const inspectKey = inspectKeyPrefix + inspectKeySuffix;
+                if (info[inspectKey] !== undefined)
+                    return [mappingTarget, inspectKeySuffix == 'LanguageValue'];
+            }
         }
         // Shouldn't get here unless new configuration targets get added to the
         // VSCode API, only those sources have values for this setting, and this


### PR DESCRIPTION
This button toggles the `cortex-debug.variableUseNaturalFormat` setting. Its value can come from the `settings.json` for the current User, Workspace, or Workspace Folder. If it is set in any of those places, modify it there. Otherwise, modify it in the User's global `settings.json`.

Fixes #1107