### PR TITLE
Remove stack trace from GDB launch error dialog box

### DIFF
--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -693,9 +693,14 @@ export class GDBDebugSession extends LoggingDebugSession {
                             commands.push(...this.args.postLaunchCommands.map(COMMAND_MAP));
                         }
                     } catch (err) {
-                        const msg = err.toString() + '\n' + err.stack.toString();
-                        this.sendEvent(new TelemetryEvent('Error', 'Launching GDB', `Failed to generate gdb commands: ${msg}`));
-                        this.launchErrorResponse(response, 104, `Failed to generate gdb commands: ${msg}`);
+                        let msg: string;
+                        if (err instanceof MIError) {
+                            msg = `Failed to initialize GDB: ${err.message}\n\nFailed on command:\n${err.source}`;
+                        } else {
+                            msg = 'Failed to generate gdb commands: ' + err.toString() + '\n' + err.stack.toString();
+                        }
+                        this.sendEvent(new TelemetryEvent('Error', 'Launching GDB', msg));
+                        this.launchErrorResponse(response, 104, msg);
                         return doResolve();
                     }
 


### PR DESCRIPTION
This is a little UI cleanup that didn't make it into PR #1097 before it got merged. The stack trace isn't really appropriate to include in this situation, since the error isn't the result of a bug in cortex-debug, but more likely an end user error like a mistake in `launch.json`.

The revised dialog box without the stack trace looks like this:

![Screenshot from 2025-04-11 14-59-12](https://github.com/user-attachments/assets/71374bb7-63f6-47eb-bd5a-15fe833b8bdb)

I don't have strong opinions about the exact wording of the error, let me know if there is some other way you'd like it phrased, I'll get to it quickly.