### PR TITLE
MI2.getStack(): use `file=` field of `stack-list-frames` reply if `fullname=` is missing

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -833,7 +833,7 @@ export class MI2 extends EventEmitter implements IBackend {
                     ret.push({
                         address: addr,
                         fileName: filename,
-                        file: file,
+                        file: file || filename,
                         function: func || from,
                         level: level,
                         line: line


### PR DESCRIPTION
When Python Frame Filters are used, GDB doesn't include a fullname= field in its -stack-list-frames response record. Fall back to the value of file= instead of reporting Unknown Source.

Fixes #1155