### PR TITLE
Add support for custom gdbHost in jlink servertype

### DIFF
--- a/debug_attributes.md
+++ b/debug_attributes.md
@@ -32,6 +32,7 @@ If the type is marked as `{...}` it means that it is a complex item can have mul
 | debuggerArgs | array | Both | Additional arguments to pass to GDB command line |
 | device | string | Both | Target Device Identifier |
 | executable | string | Both | Path of executable for symbols and program information. See also `loadFiles`, `symbolFiles` |
+| gdbHost | string | Both | Host for the GDB server connection (defaults to localhost). Only used for servertype jlink. |
 | gdbInterruptMode | string | Both | Whether GDB shall be interrupted using "exec-interrupt" (default) or by signaling "SIGINT" |
 | gdbPath | string | Both | This setting can be used to override the GDB path user/workspace setting for a particular launch configuration. This should be the full pathname to the executable (or name of the executable if it is in your PATH). Note that other toolchain executables with the configured prefix must still be available. |
 | gdbTarget | string | Both | For externally (servertype = "external") controlled GDB Servers you must specify the GDB target to connect to. This can either be a "hostname:port" combination or path to a serial port |

--- a/package.json
+++ b/package.json
@@ -1618,6 +1618,11 @@
                                 "description": "J-Link script file - optional input file for customizing J-Link actions.",
                                 "type": "string"
                             },
+                            "gdbHost": {
+                                "default": null,
+                                "description": "Host for the GDB server connection (defaults to localhost). Only used for servertype jlink.",
+                                "type": "string"
+                            },
                             "openOCDLaunchCommands": {
                                 "default": [],
                                 "description": "OpenOCD command(s) after configuration files are loaded (-c options)",
@@ -2841,6 +2846,11 @@
                             "jlinkscript": {
                                 "default": null,
                                 "description": "J-Link script file - optional input file for customizing J-Link actions.",
+                                "type": "string"
+                            },
+                            "gdbHost": {
+                                "default": null,
+                                "description": "Host for the GDB server connection (defaults to localhost). Only used for servertype jlink.",
                                 "type": "string"
                             },
                             "openOCDLaunchCommands": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -335,6 +335,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     ipAddress: string;
     serialNumber: string;
     jlinkscript: string;
+    gdbHost: string;
 
     // OpenOCD Specific
     configFiles: string[];

--- a/src/jlink.ts
+++ b/src/jlink.ts
@@ -33,9 +33,9 @@ export class JLinkServerController extends EventEmitter implements GDBServerCont
 
     public initCommands(): string[] {
         const gdbport = this.ports[createPortName(this.args.targetProcessor)];
-
+        const host = this.args.gdbHost || 'localhost';
         return [
-            `target-select extended-remote localhost:${gdbport}`
+            `target-select extended-remote ${host}:${gdbport}`
         ];
     }
 


### PR DESCRIPTION
This adds support for specifying the host for GDB when running with "servertype": "jlink".

This is to allow running the build environment and GDB runs in WSL, while having JLinkGDBServerCL run in Windows and thus avoiding mapping the USB device into WSL.

If not set, it defaults to localhost to maintain backwards compatibility.

In my setup I have the following lines in settings.json:
```json
{
    "cortex-debug.JLinkGDBServerPath": "/mnt/c/Program Files/SEGGER/JLink/JLinkGDBServerCL.exe",
    "cortex-debug.gdbPath": "/path/to/bin/arm-none-eabi-gdb"
}
```

And add the following lines to launch.json:
```json
"gdbHost": "172.X.Y.1",
"serverArgs": [
    "-nolocalhostonly",
],
```

But as the WSL IP might change, it can be automatically updated, for example by using the `augustocdias.tasks-shell-input` extension and:
```json
"configurations": [
    {
        "name": "Debug with J-Link",
        "gdbHost": "${input:wslHostIp}",
        "serverArgs": [
            "-nolocalhostonly",
        ],
        ...
    }
],
"inputs": [
    {
        "id": "wslHostIp",
        "type": "command",
        "command": "shellCommand.execute",
        "args": {
            "command": "ip route show | grep -i default | awk '{ print $3}'",
            "cwd": "${workspaceFolder}",
            "useSingleResult": true
        },
    }
]
```