### PR TITLE
fix(stlink): pass value of `targetProcessor` to `-m` flag

### DIFF
--- a/src/stlink.ts
+++ b/src/stlink.ts
@@ -265,7 +265,7 @@ export class STLinkServerController extends EventEmitter implements GDBServerCon
         }
         serverargs.push('--halt');      // Need this for reset to work as expected (perform a halt)
         if (this.targetProcessor > 0) {
-            serverargs.push('-m', `this.targetProcessor`);
+            serverargs.push('-m', `${this.targetProcessor}`);
         }
 
         if (this.args.serverArgs) {


### PR DESCRIPTION
https://github.com/Marus/cortex-debug/blob/ed5a1eb0185f7d229d857b5846a1de9c6cd980b8/src/stlink.ts#L268

This added the string `"this.TargetProcessor"` as the argument of the `-m` flag:
```
"C:\\ST\\STM32CubeCLT_1.20.0\\STLink-gdb-server\\bin\\ST-LINK_gdbserver.exe" -p 50000 -cp "C:\\ST\\STM32CubeCLT_1.20.0\\STM32CubeProgrammer\\bin" --swd --halt -m this.targetProcessor
```

I think this should be something like this, to pass the (string) value instead.
```ts
serverargs.push('-m', `${this.targetProcessor}`);
```

---
Sorry for creating a comment on the commit e00cc71b762f31202b3860c5dc68c2f2e3e0eeec before. Don't know who or if that notified someone, but I deleted it and created this pr instead.