### PR TITLE
BMP: added missing 'enable' keyword

### DIFF
--- a/src/bmp.ts
+++ b/src/bmp.ts
@@ -90,7 +90,7 @@ export class BMPServerController extends EventEmitter implements GDBServerContro
         const encoding = this.args.swoConfig.swoEncoding === 'manchester' ? 1 : 2;
 
         if (this.args.swoConfig.source === 'probe') {
-            commands.push(encoding === 2 ? `monitor traceswo ${swoFrequency}` : 'monitor traceswo');
+            commands.push(encoding === 2 ? `monitor traceswo enable ${swoFrequency}` : 'monitor traceswo enable');
         }
 
         return commands.map((c) => `interpreter-exec console "${c}"`);


### PR DESCRIPTION
BMP now requires one extra keyword for setting up trace via SWO. Without it, its configuration fails:

```
'enable' or 'disable' argument must be provided
Usage: traceswo <enable|disable> [2000000] [decode [0 1 3 31]]
Failed
```