### PR TITLE
feat(live-watch): support setting values from live watch while running

### DIFF
--- a/package.json
+++ b/package.json
@@ -441,6 +441,11 @@
                 "icon": "$(edit)"
             },
             {
+                "command": "cortex-debug.liveWatch.setValue",
+                "title": "Set live value",
+                "icon": "$(symbol-number)"
+            },
+            {
                 "command": "cortex-debug.liveWatch.moveUp",
                 "title": "Move expression up",
                 "icon": "$(arrow-up)"
@@ -3046,6 +3051,16 @@
             ],
             "view/item/context": [
                 {
+                    "command": "cortex-debug.liveWatch.setValue",
+                    "when": "view == cortex-debug.liveWatch && inDebugMode && debugType == 'cortex-debug' && viewItem == expression",
+                    "group": "inline"
+                },
+                {
+                    "command": "cortex-debug.liveWatch.setValue",
+                    "when": "view == cortex-debug.liveWatch && inDebugMode && debugType == 'cortex-debug' && viewItem == field",
+                    "group": "inline"
+                },
+                {
                     "command": "cortex-debug.liveWatch.editExpr",
                     "when": "view == cortex-debug.liveWatch && viewItem == expression",
                     "group": "inline"
@@ -3106,7 +3121,7 @@
             "debug/variables/context": [
                 {
                     "command": "cortex-debug.liveWatch.addToLiveWatch",
-                    "when": "inDebugMode && debugType == 'cortex-debug' && debugState == stopped",
+                    "when": "inDebugMode && debugType == 'cortex-debug'",
                     "group": "navigation"
                 }
             ]

--- a/src/frontend/extension.ts
+++ b/src/frontend/extension.ts
@@ -82,6 +82,7 @@ export class CortexDebugExtension {
             vscode.commands.registerCommand('cortex-debug.liveWatch.removeExpr', this.removeLiveWatchExpr.bind(this)),
             vscode.commands.registerCommand('cortex-debug.liveWatch.editExpr', this.editLiveWatchExpr.bind(this)),
             vscode.commands.registerCommand('cortex-debug.liveWatch.addToLiveWatch', this.addToLiveWatch.bind(this)),
+            vscode.commands.registerCommand('cortex-debug.liveWatch.setValue', this.setLiveWatchValue.bind(this)),
             vscode.commands.registerCommand('cortex-debug.liveWatch.moveUp', this.moveUpLiveWatchExpr.bind(this)),
             vscode.commands.registerCommand('cortex-debug.liveWatch.moveDown', this.moveDownLiveWatchExpr.bind(this)),
 
@@ -903,6 +904,10 @@ export class CortexDebugExtension {
 
     private editLiveWatchExpr(node: any) {
         this.liveWatchProvider.editNode(node);
+    }
+
+    private setLiveWatchValue(node: any) {
+        this.liveWatchProvider.setNodeValue(node);
     }
 
     private moveUpLiveWatchExpr(node: any) {

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -1285,6 +1285,17 @@ export class GDBDebugSession extends LoggingDebugSession {
                     this.sendResponse(response);
                 }
                 break;
+            case 'liveSetExpression':
+                if (this.miLiveGdb) {
+                    try {
+                        response.body = await this.miLiveGdb.setExpression(args);
+                    } catch (e) {
+                        this.sendErrorResponse(response, 11, `Could not set expression '${args?.expression}'\n${e}`);
+                        return;
+                    }
+                }
+                this.sendResponse(response);
+                break;
             case 'is-global-or-static': {
                 const varRef = args.varRef;
                 const id = this.variableHandles.get(varRef);


### PR DESCRIPTION
This PR adds a Keil-like Live Watch write workflow for Cortex-Debug:
- Add expressions to Live Watch from Variables view without requiring a stopped state.
- Set value directly from Live Watch context menu (`expression` and nested `field` nodes).
- Route writes through a new debug-adapter custom request on the live GDB channel, then refresh the displayed value.

The goal is to improve interactive debugging ergonomics for global/static variables and nested fields, especially in live-refresh scenarios.

**What Changed**
- `src/frontend/extension.ts`
  - Register new command: `cortex-debug.liveWatch.setValue`.
- `src/frontend/views/live-watch.ts`
  - Add node value getter.
  - Add `setNodeValue(...)`:
    - prompts input value,
    - sends `customRequest('liveSetExpression', { expression, value, context: 'hover' })`,
    - refreshes live watch tree after write.
- `src/gdb.ts`
  - Add custom request branch: `liveSetExpression`.
  - Delegate write to `miLiveGdb.setExpression(...)`.
- `src/live-watch-monitor.ts`
  - Add `setExpression(...)` on live monitor:
    - create/reuse floating var-object for expression,
    - perform assignment via `exprAssign(...)`,
    - refresh value via `varUpdate(...)`, with fallback to `varEvalExpression(...)`.
- `package.json`
  - Add command contribution: `cortex-debug.liveWatch.setValue`.
  - Add context-menu entries for Live Watch items (`expression` and `field`).
  - Relax `debug/variables/context` condition for `cortex-debug.liveWatch.addToLiveWatch` by removing `debugState == stopped`.

**Behavior Notes**
- “Add to Live Watch” entry is now available in debug mode for Cortex-Debug (not only when stopped).
- Live Watch supports right-click “Set live value” on:
  - top-level expressions,
  - expanded nested fields.
- Write path is implemented through live monitor (`miLiveGdb`) to fit live-watch polling architecture.

**Validation**
Executed locally in `..\cortex-debug`:
- `npm ci`
- `npm run compile` ✅
- `npm run lint` ✅

`npm run test-compile` still reports existing project typing issues related to `@types/w3c-web-usb` / DOM types, unrelated to this change.

**Scope / Non-Goals**
- No protocol-breaking changes.
- No new launch.json options.
- No UI redesign; only command/menu/functional wiring for live write.

**Potential Follow-ups**
- Improve error mapping/messages for live write failures (e.g. target state / invalid expression / backend limitation).
- Add integration test coverage around `liveSetExpression` custom request path.
