### PR TITLE
Allow loading with -device file=mybin.elf

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -275,6 +275,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     gdbInterruptMode: GDBInterruptMode;
     objdumpPath: string;
     serverArgs: string[];
+    serverOptionLoadWithDeviceFile: boolean;
     serverCwd: string;
     device: string;
     loadFiles: string[];

--- a/src/qemu.ts
+++ b/src/qemu.ts
@@ -84,13 +84,15 @@ export class QEMUServerController extends EventEmitter implements GDBServerContr
             '-semihosting-config', 'enable=on,target=native',
             '-gdb', 'tcp::' + gdbport.toString(),
             '-S',
-            '-kernel', this.args.executable
         ];
-
+        if (this.args.serverOptionLoadWithDeviceFile) {
+            cmdargs = cmdargs.concat('-device', 'loader,file=' + this.args.executable);
+        } else {
+            cmdargs = cmdargs.concat('-kernel', this.args.executable);
+        };
         if (this.args.serverArgs) {
             cmdargs = cmdargs.concat(this.args.serverArgs);
-        }
-
+        };
         return cmdargs;
     }
 


### PR DESCRIPTION
For some reason my qemu wants to be loaded with `-device loader,file=executable.elf` instead of `-kernel executable.elf` this option solved my need.