### PR TITLE
Bump github action versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,14 +11,14 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
       - name: Cache NPM Install
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ./node_modules
           key: npm-${{ hashFiles('./package-lock.json') }}
@@ -32,14 +32,14 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
       - name: Load NPM install
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ./node_modules
           key: npm-${{ hashFiles('./package-lock.json') }}
@@ -48,7 +48,7 @@ jobs:
       - name: Package Binary
         run: ./node_modules/vsce/vsce package -o cortex-debug.vsix
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cortex-debug.vsix
           path: ./cortex-debug.vsix
@@ -58,14 +58,14 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
       - name: Load NPM install
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ./node_modules
           key: npm-${{ hashFiles('./package-lock.json') }}


### PR DESCRIPTION
Remove warning:
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v3, actions/checkout@v3, actions/setup-node@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/