### PR TITLE
Re-added support for 'Jump to Cursor' command

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -565,6 +565,18 @@ export class MI2 extends EventEmitter implements IBackend {
         });
     }
 
+    public goto(filename: string, line: number): Thenable<boolean> {
+        if (trace) {
+            this.log('stderr', 'goto');
+        }
+        return new Promise((resolve, reject) => {
+            const target = `"${filename ? `${escape(filename)}:` : ''}${line.toString()}"`;
+            this.sendCommand(`exec-jump ${target}`).then((info) => {
+                resolve(info.resultRecords.resultClass === 'running');
+            }, reject);
+        });
+    }
+
     public restart(commands: string[]): Thenable<boolean> {
         if (trace) {
             this.log('stderr', 'restart');

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -256,6 +256,7 @@ export class GDBDebugSession extends LoggingDebugSession {
 
     protected variableHandles = new Handles<string | VariableObject | ExtendedVariable>(HandleRegions.VAR_HANDLES_START);
     protected variableHandlesReverse = new Map<string, number>();
+    protected gotoTargetHandles = new Handles<OurSourceBreakpoint>(1);
     protected quit!: boolean;
     protected attached!: boolean;
     protected started!: boolean;
@@ -3594,10 +3595,45 @@ export class GDBDebugSession extends LoggingDebugSession {
     }
 
     protected async gotoTargetsRequest(response: DebugProtocol.GotoTargetsResponse, args: DebugProtocol.GotoTargetsArguments): Promise<void> {
+        const file = args.source?.path;
+        if (!file) {
+            this.sendErrorResponse(response, 16, `Could not jump to: ${args.line}`);
+            return;
+        }
+
+        const targetId = this.gotoTargetHandles.create({
+            file: file,
+            line: args.line,
+            column: args.column
+        });
+
+        response.body = {
+            targets: [{
+                id: targetId,
+                label: args.source.name || path.basename(file),
+                column: args.column,
+                line: args.line
+            }]
+        };
+        this.sendResponse(response);
+    }
+
+    protected async gotoRequest(response: DebugProtocol.GotoResponse, args: DebugProtocol.GotoArguments): Promise<void> {
+        if (this.isBusy()) {
+            this.busyError(response, args);
+            return;
+        }
+
+        const target = this.gotoTargetHandles.get(args.targetId);
+        if (!target?.file) {
+            this.sendErrorResponse(response, 16, `Could not jump to target ${args.targetId}`);
+            return;
+        }
+
         try {
             const brk: OurSourceBreakpoint = {
-                file: args.source.path,
-                line: args.line,
+                file: target.file,
+                line: target.line,
                 isTemporary: true,
                 hwOpt: this.hwBreakpointMgr.getGdbMiArg('src')
             };
@@ -3607,22 +3643,23 @@ export class GDBDebugSession extends LoggingDebugSession {
             }, brk);
 
             if (result instanceof MIError) {
-                this.sendErrorResponse(response, 16, `Could not jump to: ${result.message} ${args.source.path}:${args.line}`);
-            } else if (!result) {
-                this.sendErrorResponse(response, 16, `Could not jump to: ${args.source.path}:${args.line}`);
-            } else {
-                response.body = {
-                    targets: [{
-                        id: result.number || 0,
-                        label: args.source.name || '',
-                        column: args.column,
-                        line: args.line
-                    }]
-                };
-                this.sendResponse(response);
+                this.sendErrorResponse(response, 16, `Could not jump to: ${result.message} ${target.file}:${target.line}`);
+                return;
             }
+            if (!result) {
+                this.sendErrorResponse(response, 16, `Could not jump to: ${target.file}:${target.line}`);
+                return;
+            }
+
+            const done = await this.miDebugger.goto(target.file, target.line);
+            if (!done) {
+                this.sendErrorResponse(response, 16, `Could not jump to: ${target.file}:${target.line}`);
+                return;
+            }
+
+            this.sendResponse(response);
         } catch (msg) {
-            this.sendErrorResponse(response, 16, `Could not jump to: ${msg ? msg : ''} ${args.source.path}:${args.line}`);
+            this.sendErrorResponse(response, 16, `Could not jump to: ${msg ? msg : ''} ${target.file}:${target.line}`);
         }
     }
 }


### PR DESCRIPTION
This PR restores Jump to Cursor behavior and aligns the adapter with expected DAP request flow, see Issue #1226 

I found the original feature implementation for 'Jump to Cursor' in PR #417 and Issue #418, but it seems to have been broken during a refactor in commit 1ff878c.
* 6ac5c31, “Jump to cursor, PR 417”, added Jump to Cursor support
* 1ff878c, “hardwareBreakpoints to force HW only bpts”, removed the low-level MI goto helper and changed gotoTargetsRequest to create a temporary breakpoint instead

Current master still advertises supportsGotoTargetsRequest, and the changelog still says Jump to Cursor is supported, but I cannot find a gotoRequest implementation in the adapter anymore, and the MI backend no longer has the exec-jump path that PR #417 added. So this looks like a partial DAP implementation now: gotoTargetsRequest exists, but the actual goto step appears to be missing. When running the code, Jump to Cursor returns the error message shown in the image below.