### PR TITLE
Make GDB startup timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 # V1.13.0-pre9
+* Added `gdbStartupTimeout` launch configuration to control how long Cortex-Debug waits for GDB to respond during startup.
 * Backed out change where we try "monitor exit". See [Issue #1185](https://github.com/Marus/cortex-debug/issues/1185)
 * Increased server temout to 10 mins
 * Fix for https://github.com/Marus/cortex-debug/issues/1167 Race comdition in parallel reading of multiple symbol files

--- a/debug_attributes.md
+++ b/debug_attributes.md
@@ -34,6 +34,7 @@ If the type is marked as `{...}` it means that it is a complex item can have mul
 | executable | string | Both | Path of executable for symbols and program information. See also `loadFiles`, `symbolFiles` |
 | gdbInterruptMode | string | Both | Whether GDB shall be interrupted using "exec-interrupt" (default) or by signaling "SIGINT" |
 | gdbPath | string | Both | This setting can be used to override the GDB path user/workspace setting for a particular launch configuration. This should be the full pathname to the executable (or name of the executable if it is in your PATH). Note that other toolchain executables with the configured prefix must still be available. |
+| gdbStartupTimeout | number | Both | Maximum time in milliseconds to wait for GDB to respond during startup before treating launch as failed. |
 | gdbTarget | string | Both | For externally (servertype = "external") controlled GDB Servers you must specify the GDB target to connect to. This can either be a "hostname:port" combination or path to a serial port |
 | graphConfig | {object} | Both | Description of how graphing can be done. See our Wiki for details |
 | hardwareBreakpoints | object | Both | WARNING: Force only HW breakpoints to be used. By default GDB will use HW or SW  breakpoints depending on memory type. Use this only in rare circumstances to work around issues in your gdb-server or hardware. This setting is NOT recommended for general use. |

--- a/package.json
+++ b/package.json
@@ -554,7 +554,7 @@
                                 "items": "string"
                             },
                             "gdbStartupTimeout": {
-                                "default": 10000,
+                                "default": 5000,
                                 "description": "Maximum time in milliseconds to wait for GDB to respond during startup before treating launch as failed.",
                                 "type": "number",
                                 "minimum": 1
@@ -1729,7 +1729,7 @@
                                 "type": "array"
                             },
                             "gdbStartupTimeout": {
-                                "default": 10000,
+                                "default": 5000,
                                 "description": "Maximum time in milliseconds to wait for GDB to respond during startup before treating launch as failed.",
                                 "type": "number",
                                 "minimum": 1

--- a/package.json
+++ b/package.json
@@ -553,6 +553,12 @@
                                 "type": "array",
                                 "items": "string"
                             },
+                            "gdbStartupTimeout": {
+                                "default": 10000,
+                                "description": "Maximum time in milliseconds to wait for GDB to respond during startup before treating launch as failed.",
+                                "type": "number",
+                                "minimum": 1
+                            },
                             "preAttachCommands": {
                                 "default": [],
                                 "type": "array",
@@ -1721,6 +1727,12 @@
                                 "default": [],
                                 "description": "Additional arguments to pass to GDB command line",
                                 "type": "array"
+                            },
+                            "gdbStartupTimeout": {
+                                "default": 10000,
+                                "description": "Maximum time in milliseconds to wait for GDB to respond during startup before treating launch as failed.",
+                                "type": "number",
+                                "minimum": 1
                             },
                             "preLaunchCommands": {
                                 "default": [],

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -9,7 +9,7 @@ import { posix } from 'path';
 import * as os from 'os';
 import { ServerConsoleLog } from '../server';
 import { hexFormat } from '../../frontend/utils';
-import { ADAPTER_DEBUG_MODE, GDBInterruptMode } from '../../common';
+import { ADAPTER_DEBUG_MODE, DEFAULT_GDB_STARTUP_TIMEOUT, GDBInterruptMode, sanitizeGDBStartupTimeout } from '../../common';
 const path = posix;
 
 export interface ReadMemResults {
@@ -68,6 +68,7 @@ export class MI2 extends EventEmitter implements IBackend {
     protected lastContinueSeqId = -1;
     protected actuallyStarted = false;
     protected isExiting = false;
+    public startupTimeout = DEFAULT_GDB_STARTUP_TIMEOUT;
     // public gdbVarsPromise: Promise<MINode> = null;
 
     constructor(public application: string, public args: string[], public forLiveGdb = false) {
@@ -90,13 +91,14 @@ export class MI2 extends EventEmitter implements IBackend {
             });
 
             if (!this.forLiveGdb) {
+                const startupTimeout = sanitizeGDBStartupTimeout(this.startupTimeout);
                 let timeout = setTimeout(() => {
                     this.gdbStartError();
                     setTimeout(() => {
                         reject(new Error('Could not start gdb, no response from gdb'));
                     }, 10);
                     timeout = undefined;
-                }, 10 * 1000);
+                }, startupTimeout);
 
                 const swallOutput = this.debugOutput ? false : true;
                 let v;
@@ -195,8 +197,9 @@ export class MI2 extends EventEmitter implements IBackend {
 
     private gdbStartError() {
         if (!this.actuallyStarted) {
+            const startupTimeout = sanitizeGDBStartupTimeout(this.startupTimeout);
             this.log('log',
-                'Error: Unable to start GDB even after 5 seconds or it couldn\'t even start '
+                `Error: Unable to start GDB even after ${startupTimeout} ms or it couldn't even start `
                 + 'Make sure you can start gdb from the command-line and run any command like "echo hello".\n');
             this.log('log', '    If you cannot, it is most likely because "libncurses" or "python" is not installed. Some GDBs require these\n');
         }

--- a/src/common.ts
+++ b/src/common.ts
@@ -66,7 +66,7 @@ export class StoppedEvent extends Event implements DebugProtocol.Event {
 }
 
 export const SocketTimout = 1000 * 60 * 5;
-export const DEFAULT_GDB_STARTUP_TIMEOUT = 10 * 1000;
+export const DEFAULT_GDB_STARTUP_TIMEOUT = 5 * 1000;
 export interface SWOConfigureBody {
     type: string;
     args: any;            // Configuration arguments

--- a/src/common.ts
+++ b/src/common.ts
@@ -66,6 +66,7 @@ export class StoppedEvent extends Event implements DebugProtocol.Event {
 }
 
 export const SocketTimout = 1000 * 60 * 5;
+export const DEFAULT_GDB_STARTUP_TIMEOUT = 10 * 1000;
 export interface SWOConfigureBody {
     type: string;
     args: any;            // Configuration arguments
@@ -271,6 +272,7 @@ export interface ConfigurationArguments extends DebugProtocol.LaunchRequestArgum
     servertype: string;
     serverpath: string;
     gdbPath: string;
+    gdbStartupTimeout: number;
     gdbServerConsolePort: number;
     gdbInterruptMode: GDBInterruptMode;
     objdumpPath: string;
@@ -795,6 +797,15 @@ export function sanitizeDevDebug(config: { showDevDebugOutput?: string | boolean
         return false;       // Meaning, needed adjustment
     }
     return true;
+}
+
+export function sanitizeGDBStartupTimeout(value: unknown): number {
+    if ((typeof value !== 'number') && (typeof value !== 'string')) {
+        return DEFAULT_GDB_STARTUP_TIMEOUT;
+    }
+
+    const timeout = Math.trunc(Number(value));
+    return Number.isFinite(timeout) && (timeout > 0) ? timeout : DEFAULT_GDB_STARTUP_TIMEOUT;
 }
 
 //

--- a/src/frontend/configprovider.ts
+++ b/src/frontend/configprovider.ts
@@ -5,7 +5,7 @@ import { STLinkServerController } from './../stlink';
 import { GDBServerConsole } from './server_console';
 import {
     ADAPTER_DEBUG_MODE, ChainedConfigurations, ChainedEvents, CortexDebugKeys,
-    sanitizeDevDebug, validateELFHeader, SymbolFile, defSymbolFile
+    sanitizeDevDebug, sanitizeGDBStartupTimeout, validateELFHeader, SymbolFile, defSymbolFile
 } from '../common';
 import { CDebugChainedSessionItem, CDebugSession } from './cortex_debug_session';
 import * as path from 'path';
@@ -201,6 +201,7 @@ export class CortexDebugConfigurationProvider implements vscode.DebugConfigurati
             const modes = Object.values(ADAPTER_DEBUG_MODE).join(',');
             vscode.window.showInformationMessage(`launch.json: "showDevDebugOutput" muse be one of ${modes}. Setting to "${config.showDevDebugOutput}"`);
         }
+        config.gdbStartupTimeout = sanitizeGDBStartupTimeout(config.gdbStartupTimeout);
 
         if (config.armToolchainPath) { config.toolchainPath = config.armToolchainPath; }
         this.setOsSpecficConfigSetting(config, 'toolchainPath', 'armToolchainPath');

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -1048,6 +1048,7 @@ export class GDBDebugSession extends LoggingDebugSession {
         }
 
         this.miDebugger = new MI2(gdbExePath, gdbargs);
+        this.miDebugger.startupTimeout = this.args.gdbStartupTimeout;
         this.miDebugger.debugOutput = this.args.showDevDebugOutput;
         if (this.args.gdbInterruptMode) {
             this.miDebugger.interruptMode = this.args.gdbInterruptMode;
@@ -1114,6 +1115,7 @@ export class GDBDebugSession extends LoggingDebugSession {
         const mi2 = new MI2(this.miDebugger.application, this.miDebugger.args, true);
         liveGdb.setupEvents(mi2);
         const commands = [...this.gdbInitCommands];
+        mi2.startupTimeout = this.args.gdbStartupTimeout;
         mi2.debugOutput = this.args.showDevDebugOutput;
         if (this.args.gdbInterruptMode) {
             mi2.interruptMode = this.args.gdbInterruptMode;

--- a/test/suite/common.test.ts
+++ b/test/suite/common.test.ts
@@ -1,0 +1,14 @@
+import * as assert from 'assert';
+import { DEFAULT_GDB_STARTUP_TIMEOUT, sanitizeGDBStartupTimeout } from '../../src/common';
+
+suite('Common helpers', () => {
+    test('GDB startup timeout sanitizer', () => {
+        assert.strictEqual(sanitizeGDBStartupTimeout(30000), 30000);
+        assert.strictEqual(sanitizeGDBStartupTimeout('45000'), 45000);
+        assert.strictEqual(sanitizeGDBStartupTimeout(1234.56), 1234);
+        assert.strictEqual(sanitizeGDBStartupTimeout(undefined), DEFAULT_GDB_STARTUP_TIMEOUT);
+        assert.strictEqual(sanitizeGDBStartupTimeout(0), DEFAULT_GDB_STARTUP_TIMEOUT);
+        assert.strictEqual(sanitizeGDBStartupTimeout(-1), DEFAULT_GDB_STARTUP_TIMEOUT);
+        assert.strictEqual(sanitizeGDBStartupTimeout('invalid'), DEFAULT_GDB_STARTUP_TIMEOUT);
+    });
+});


### PR DESCRIPTION
Summary:
- Add gdbStartupTimeout launch/attach configuration with schema and docs.
- Keep the default startup wait at 5000 ms while allowing slower systems to override it.
- Apply the configured timeout when waiting for the initial GDB response.
- Update the startup error message and add sanitizer coverage.

Tests:
- npm run test-compile
- npm run lint
- npx mocha --ui tdd out/test/suite/common.test.js